### PR TITLE
refactor: context awareness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ kubewarden-policy-sdk = "0.2.2"
 lazy_static = "1.4.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "^1" }
 tracing = "0.1"
 tracing-futures = "0.2"
 validator = { version = "0.13", features = ["derive"] }

--- a/src/cluster_context.rs
+++ b/src/cluster_context.rs
@@ -1,50 +1,18 @@
-#![allow(clippy::mutex_atomic)]
-
-use anyhow::Result;
 use kube::api::{ListParams, Resource};
 use kube::Client;
-use std::sync::{Mutex, RwLock};
-use tokio::runtime::Builder;
+use std::sync::RwLock;
 
 use k8s_openapi::api::core::v1::{Namespace, Service};
 use k8s_openapi::api::networking::v1::Ingress;
 
 use lazy_static::lazy_static;
-use std::thread;
 
 lazy_static! {
-    static ref CLUSTER_CONTEXT_INITIALIZED: Mutex<bool> = Mutex::new(false);
     static ref CLUSTER_CONTEXT: ClusterContext = ClusterContext::default();
 }
 
 // ClusterContext represents a structure that can be used to retrieve
 // information about a running Kubernetes cluster.
-//
-// In the current implementation, the `ClusterContext` contains a set
-// of well known resources. This resources get exposed through the
-// waPC host callback and are readable by waPC guests as JSON encoded
-// raw strings.
-//
-// The current implementation performs a list of this well known
-// resources every 5 seconds. Two things need to be improved at least
-// in the current implementation:
-//
-// 1. Do not limit to a reduced number of well-known types. Generalize
-// the supported types, and by generalizing support custom resource
-// definitions too. This allows guest waPC policies to take contextual
-// decisions based on custom resources defined by the user.
-//
-// 2. Do not use polling. Perform an initial list request of resources
-// when the first request is performed by a guest. Then, cache and
-// watch in order to maintain an updated list: this significantly
-// reduces the data that needs to be pulled in a scheduled basis.
-//
-// Synchronization of the ClusterContext data structure happens by
-// protecting all inner shared resources with a RwLock. This enables
-// us to differentiate between reader locks and writer lock. Only one
-// writer exists, that will currently perform an active poll and
-// request information to the API server. Many readers may exist (many
-// policies reading the latest information from the cluster context).
 #[derive(Default)]
 pub struct ClusterContext {
     ingresses: RwLock<String>,
@@ -53,39 +21,6 @@ pub struct ClusterContext {
 }
 
 impl ClusterContext {
-    // Initialize a ClusterContext. With the current implementation
-    // this will start an active polling loop.
-    #[allow(unused_must_use)]
-    pub fn init() -> Result<()> {
-        let mut context_initialized = CLUSTER_CONTEXT_INITIALIZED.lock().unwrap();
-        if *context_initialized {
-            return Ok(());
-        }
-        *context_initialized = true;
-        thread::spawn(|| {
-            let rt = match Builder::new_current_thread().enable_all().build() {
-                Ok(r) => r,
-                Err(error) => {
-                    panic!("error initializing tokio runtime: {}", error);
-                }
-            };
-            let kubernetes_client = match rt.block_on(Client::try_default()) {
-                Ok(kubernetes_client) => Some(kubernetes_client),
-                Err(error) => {
-                    eprintln!("could not initialize a Kubernetes client due to error: {}; contextual policies might misbehave since they will lack cluster information", error);
-                    None
-                }
-            };
-            if let Some(kubernetes_client) = kubernetes_client {
-                loop {
-                    rt.block_on(ClusterContext::get().refresh(&kubernetes_client));
-                    thread::sleep(std::time::Duration::from_secs(5));
-                }
-            }
-        });
-        Ok(())
-    }
-
     pub fn get<'a>() -> &'a ClusterContext {
         &CLUSTER_CONTEXT
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 extern crate k8s_openapi;
 extern crate kube;
-extern crate tokio;
 extern crate wasmparser;
 
 pub mod cluster_context;

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -126,6 +126,8 @@ pub struct Metadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<HashMap<String, String>>,
     pub mutating: bool,
+    #[serde(default)]
+    pub context_aware: bool,
 }
 
 impl Default for Metadata {
@@ -135,6 +137,7 @@ impl Default for Metadata {
             rules: vec![],
             annotations: Some(HashMap::new()),
             mutating: false,
+            context_aware: false,
         }
     }
 }
@@ -179,8 +182,7 @@ mod tests {
         let metadata = Metadata {
             protocol_version: Some(ProtocolVersion::V1),
             rules: vec![pod_rule],
-            annotations: None,
-            mutating: false,
+            ..Default::default()
         };
         assert!(metadata.validate().is_ok());
 
@@ -203,6 +205,7 @@ mod tests {
             annotations: None,
             rules: vec![pod_rule],
             mutating: false,
+            ..Default::default()
         };
         assert!(metadata.validate().is_err());
 
@@ -226,7 +229,7 @@ mod tests {
         metadata.rules = vec![pod_rule];
         assert!(metadata.validate().is_err());
 
-        // faile because there's no valid protocol version defined
+        // fails because there's no valid protocol version defined
         pod_rule = Rule {
             api_groups: vec![String::from("")],
             api_versions: vec![String::from("v1")],
@@ -247,9 +250,7 @@ mod tests {
         };
         metadata = Metadata {
             rules: vec![pod_rule],
-            annotations: None,
-            protocol_version: None,
-            mutating: false,
+            ..Default::default()
         };
         assert!(metadata.validate().is_err());
 
@@ -259,16 +260,16 @@ mod tests {
     #[test]
     fn metadata_without_rules() -> Result<(), ()> {
         let metadata = Metadata {
-            rules: vec![],
             protocol_version: Some(ProtocolVersion::V1),
             annotations: None,
-            mutating: false,
+            ..Default::default()
         };
 
         let expected = json!({
             "protocolVersion": "v1",
             "rules": [ ],
-            "mutating": false
+            "mutating": false,
+            "contextAware": false,
         });
 
         let actual = serde_json::to_value(&metadata).unwrap();
@@ -295,7 +296,7 @@ mod tests {
             annotations: Some(annotations),
             protocol_version: Some(ProtocolVersion::V1),
             rules: vec![pod_rule],
-            mutating: false,
+            ..Default::default()
         };
 
         let expected = json!(
@@ -312,7 +313,8 @@ mod tests {
             "annotations": {
                 "io.kubewarden.policy.author": "Flavio Castelli"
             },
-            "mutating": false
+            "mutating": false,
+            "contextAware": false,
         });
 
         let actual = serde_json::to_value(&metadata).unwrap();
@@ -345,7 +347,7 @@ mod tests {
             annotations: Some(annotations),
             protocol_version: Some(ProtocolVersion::V1),
             rules: vec![pod_rule],
-            mutating: false,
+            ..Default::default()
         };
 
         assert!(metadata.validate().is_ok());
@@ -372,7 +374,7 @@ mod tests {
             annotations: Some(annotations),
             protocol_version: Some(ProtocolVersion::V1),
             rules: vec![pod_rule],
-            mutating: false,
+            ..Default::default()
         };
 
         assert!(metadata.validate().is_err());
@@ -399,7 +401,7 @@ mod tests {
             annotations: Some(annotations),
             protocol_version: Some(ProtocolVersion::V1),
             rules: vec![pod_rule],
-            mutating: false,
+            ..Default::default()
         };
 
         assert!(metadata.validate().is_err());
@@ -425,7 +427,7 @@ mod tests {
             annotations: Some(annotations),
             protocol_version: Some(ProtocolVersion::V1),
             rules: vec![pod_rule],
-            mutating: false,
+            ..Default::default()
         };
 
         assert!(metadata.validate().is_ok());
@@ -451,7 +453,7 @@ mod tests {
             annotations: Some(annotations),
             protocol_version: Some(ProtocolVersion::V1),
             rules: vec![pod_rule],
-            mutating: false,
+            ..Default::default()
         };
 
         assert!(metadata.validate().is_err());
@@ -477,7 +479,7 @@ mod tests {
             annotations: Some(annotations),
             protocol_version: Some(ProtocolVersion::V1),
             rules: vec![pod_rule],
-            mutating: false,
+            ..Default::default()
         };
 
         assert!(metadata.validate().is_err());


### PR DESCRIPTION
The crate library will not start a refresh loop, and will let up to
the caller to refresh the context aware structure when it wants.

Related: https://github.com/kubewarden/kwctl/issues/40