### PR TITLE
feat: implement policy logging

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,1 +1,10 @@
 pub const KUBEWARDEN_CUSTOM_SECTION_METADATA: &str = "io.kubewarden.metadata";
+pub const KUBEWARDEN_ANNOTATION_POLICY_TITLE: &str = "io.kubewarden.policy.title";
+pub const KUBEWARDEN_ANNOTATION_POLICY_DESCRIPTION: &str = "io.kubewarden.policy.description";
+pub const KUBEWARDEN_ANNOTATION_POLICY_AUTHOR: &str = "io.kubewarden.policy.author";
+pub const KUBEWARDEN_ANNOTATION_POLICY_URL: &str = "io.kubewarden.policy.url";
+pub const KUBEWARDEN_ANNOTATION_POLICY_SOURCE: &str = "io.kubewarden.policy.source";
+pub const KUBEWARDEN_ANNOTATION_POLICY_LICENSE: &str = "io.kubewarden.policy.license";
+pub const KUBEWARDEN_ANNOTATION_POLICY_USAGE: &str = "io.kubewarden.policy.usage";
+
+pub const KUBEWARDEN_ANNOTATION_KWCTL_VERSION: &str = "io.kubewarden.kwctl";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ extern crate wasmparser;
 
 pub mod cluster_context;
 pub mod constants;
+mod policy;
 pub mod policy_evaluator;
 pub mod policy_metadata;
+mod policy_tracing;
 pub mod validation_response;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+use std::clone::Clone;
+use tracing::span;
+
+#[cfg(test)]
+use tracing::Level;
+
+use crate::constants::*;
+use crate::policy_metadata::Metadata;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Policy {
+    pub name: Option<String>,
+    pub settings: Option<serde_json::Map<String, serde_json::Value>>,
+    pub wapc_policy_id: u64,
+    pub span: span::Span,
+    pub request_uid: Option<String>,
+}
+
+#[cfg(test)]
+impl Default for Policy {
+    fn default() -> Self {
+        Policy {
+            name: None,
+            settings: None,
+            // This is going to be changed at creation time
+            wapc_policy_id: 1,
+            //This is going to be changed at creation time
+            span: span!(Level::INFO, "kubewarden testing"),
+            request_uid: None,
+        }
+    }
+}
+
+impl Policy {
+    pub(crate) fn from_contents(
+        policy_contents: Vec<u8>,
+        wapc_policy_id: u64,
+        span: tracing::Span,
+        settings: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<Policy> {
+        let metadata = Metadata::from_contents(policy_contents)?;
+        let policy_name: Option<String> = match metadata {
+            Some(ref metadata) => match metadata.annotations {
+                Some(ref annotations) => annotations
+                    .get(KUBEWARDEN_ANNOTATION_POLICY_TITLE)
+                    .map(Clone::clone),
+                None => None,
+            },
+            None => None,
+        };
+
+        let policy = Policy {
+            name: policy_name,
+            settings,
+            span,
+            request_uid: None,
+            wapc_policy_id,
+        };
+
+        policy.span.record("policy_name", &policy.name().as_str());
+
+        Ok(policy)
+    }
+
+    fn name(&self) -> String {
+        self.name
+            .as_ref()
+            .unwrap_or(&"unknown".to_string())
+            .to_string()
+    }
+}

--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -1,10 +1,9 @@
 use anyhow::{anyhow, Result};
-
-use serde_json::json;
-
-use std::{convert::TryFrom, fmt, fs::File, io::prelude::*, path::Path};
-
-use tracing::error;
+use lazy_static::lazy_static;
+use serde::Serialize;
+use serde_json::{json, value};
+use std::{collections::HashMap, convert::TryFrom, fmt, fs, path::Path, sync::RwLock};
+use tracing::{error, span, Level};
 
 use wapc::WapcHost;
 use wasmtime_provider::WasmtimeEngineProvider;
@@ -13,125 +12,231 @@ use kubewarden_policy_sdk::metadata::ProtocolVersion;
 use kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
 use kubewarden_policy_sdk::settings::SettingsValidationResponse;
 
+use crate::cluster_context::ClusterContext;
+use crate::policy::Policy;
 use crate::validation_response::ValidationResponse;
 
-use crate::cluster_context::ClusterContext;
+lazy_static! {
+    static ref POLICY_MAPPING: RwLock<HashMap<u64, Policy>> =
+        RwLock::new(HashMap::with_capacity(64));
+}
+
+#[derive(Serialize)]
+pub struct ValidateRequest(serde_json::Value);
+
+impl ValidateRequest {
+    pub fn new(request: serde_json::Value) -> Self {
+        ValidateRequest(request)
+    }
+
+    fn uid(&self) -> &str {
+        if let Some(uid) = self.0.get("uid").and_then(value::Value::as_str) {
+            uid
+        } else {
+            ""
+        }
+    }
+}
 
 pub(crate) fn host_callback(
-    _id: u64,
+    policy_id: u64,
     binding: &str,
     namespace: &str,
-    _operation: &str,
-    _payload: &[u8],
+    operation: &str,
+    payload: &[u8],
 ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-    let cluster_context = ClusterContext::get();
-    if binding != "kubernetes" {
-        return Err(format!("unknown binding: {}", binding).into());
-    }
-    match namespace {
-        "ingresses" => Ok(cluster_context.ingresses().into()),
-        "namespaces" => Ok(cluster_context.namespaces().into()),
-        "services" => Ok(cluster_context.services().into()),
-        _ => Err(format!("unknown namespace name: {}", namespace).into()),
+    match binding {
+        "kubewarden" => match namespace {
+            "tracing" => match operation {
+                "log" => {
+                    let policy_mapping = POLICY_MAPPING.read().unwrap();
+                    let policy = policy_mapping.get(&policy_id).unwrap();
+                    if let Err(e) = policy.log(payload) {
+                        let p =
+                            String::from_utf8(payload.to_vec()).unwrap_or_else(|e| e.to_string());
+                        error!(
+                            payload = p.as_str(),
+                            error = e.to_string().as_str(),
+                            "Cannot log event"
+                        );
+                    }
+                    Ok(Vec::new())
+                }
+                _ => {
+                    error!("unknown operation: {}", operation);
+                    Err(format!("unknown operation: {}", operation).into())
+                }
+            },
+            _ => {
+                error!("unknown namespace: {}", namespace);
+                Err(format!("unknown namespace: {}", namespace).into())
+            }
+        },
+        "kubernetes" => {
+            let cluster_context = ClusterContext::get();
+            match namespace {
+                "ingresses" => Ok(cluster_context.ingresses().into()),
+                "namespaces" => Ok(cluster_context.namespaces().into()),
+                "services" => Ok(cluster_context.services().into()),
+                _ => {
+                    error!("unknown namespace: {}", namespace);
+                    Err(format!("unknown namespace: {}", namespace).into())
+                }
+            }
+        }
+        _ => {
+            error!("unknown binding: {}", binding);
+            Err(format!("unknown binding: {}", binding).into())
+        }
     }
 }
 
 pub struct PolicyEvaluator {
     wapc_host: WapcHost,
-    settings: Option<serde_json::Map<String, serde_json::Value>>,
+    policy: Policy,
 }
 
 impl fmt::Debug for PolicyEvaluator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PolicyEvaluator")
-            .field("settings", &self.settings)
+            .field("settings", &self.policy.settings)
             .finish()
     }
 }
 
 impl PolicyEvaluator {
-    pub fn new(
-        wasm_file: &Path,
+    pub fn from_file(
+        policy_file: &Path,
         settings: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> Result<PolicyEvaluator> {
-        let mut f = File::open(&wasm_file)?;
-        let mut buf = Vec::new();
-        f.read_to_end(&mut buf)?;
+        PolicyEvaluator::from_contents(fs::read(policy_file)?, settings)
+    }
 
-        let engine = WasmtimeEngineProvider::new(&buf, None);
+    pub fn from_contents(
+        policy_contents: Vec<u8>,
+        settings: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<PolicyEvaluator> {
+        let engine = WasmtimeEngineProvider::new(&policy_contents, None);
         let wapc_host = WapcHost::new(Box::new(engine), host_callback)?;
-
-        Ok(PolicyEvaluator {
-            wapc_host,
+        let policy = PolicyEvaluator::from_contents_internal(
+            policy_contents,
+            || Ok(wapc_host.id()),
+            |policy_contents, wapc_policy_id, span, settings| {
+                Policy::from_contents(policy_contents, wapc_policy_id, span, settings)
+            },
             settings,
+        )?;
+
+        Ok(PolicyEvaluator { wapc_host, policy })
+    }
+
+    fn from_contents_internal<E, P>(
+        policy_contents: Vec<u8>,
+        engine_initializer: E,
+        policy_from_contents: P,
+        settings: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<Policy>
+    where
+        E: Fn() -> Result<u64>,
+        P: Fn(
+            Vec<u8>,
+            u64,
+            span::Span,
+            Option<serde_json::Map<String, serde_json::Value>>,
+        ) -> Result<Policy>,
+    {
+        let wapc_policy_id = engine_initializer()?;
+        let span = span!(
+            Level::INFO,
+            "kubewarden",
+            policy_id = wapc_policy_id,
+            policy_name = tracing::field::Empty,
+        );
+
+        let policy = policy_from_contents(policy_contents, wapc_policy_id, span, settings)?;
+        POLICY_MAPPING
+            .write()
+            .unwrap()
+            .insert(wapc_policy_id, policy.clone());
+
+        Ok(policy)
+    }
+
+    pub fn validate(&self, request: ValidateRequest) -> ValidationResponse {
+        self.policy.span.in_scope(|| {
+            let uid = request.uid();
+            let policy = Policy {
+                request_uid: Some(uid.to_string()),
+                ..self.policy.clone()
+            };
+
+            POLICY_MAPPING
+                .write()
+                .unwrap()
+                .insert(self.policy.wapc_policy_id, policy.clone());
+
+            let req_obj = match request.0.get("object") {
+                Some(req_obj) => req_obj,
+                None => {
+                    return ValidationResponse::reject(
+                        uid.to_string(),
+                        "request doesn't have an 'object' value".to_string(),
+                        hyper::StatusCode::BAD_REQUEST.as_u16(),
+                    );
+                }
+            };
+            let validate_params = json!({
+                "request": request,
+                "settings": policy.settings.unwrap_or_default(),
+            });
+            let validate_str = match serde_json::to_string(&validate_params) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(
+                        error = e.to_string().as_str(),
+                        "cannot serialize validation params"
+                    );
+                    return ValidationResponse::reject_internal_server_error(
+                        uid.to_string(),
+                        e.to_string(),
+                    );
+                }
+            };
+            match self.wapc_host.call("validate", validate_str.as_bytes()) {
+                Ok(res) => {
+                    let pol_val_resp: Result<PolicyValidationResponse> =
+                        serde_json::from_slice(&res).map_err(|e| {
+                            anyhow!("cannot deserialize policy validation response: {:?}", e)
+                        });
+                    pol_val_resp
+                        .and_then(|pol_val_resp| {
+                            ValidationResponse::from_policy_validation_response(
+                                uid.to_string(),
+                                &req_obj,
+                                &pol_val_resp,
+                            )
+                        })
+                        .unwrap_or_else(|e| {
+                            error!(
+                                error = e.to_string().as_str(),
+                                "cannot build validation response from policy result"
+                            );
+                            ValidationResponse::reject_internal_server_error(
+                                uid.to_string(),
+                                e.to_string(),
+                            )
+                        })
+                }
+                Err(e) => {
+                    error!(error = e.to_string().as_str(), "waPC communication error");
+                    ValidationResponse::reject_internal_server_error(uid.to_string(), e.to_string())
+                }
+            }
         })
     }
 
-    #[tracing::instrument(fields(request = request.to_string().as_str()))]
-    pub fn validate(&self, request: serde_json::Value) -> ValidationResponse {
-        let uid = request
-            .get("uid")
-            .and_then(|v| v.as_str())
-            .or(Some(""))
-            .map(|s| s.to_owned())
-            .unwrap();
-
-        let req_obj = match request.get("object") {
-            Some(req_obj) => req_obj,
-            None => {
-                return ValidationResponse::reject(
-                    uid,
-                    String::from("request doesn't have an 'object' value"),
-                    hyper::StatusCode::BAD_REQUEST.as_u16(),
-                );
-            }
-        };
-        let validate_params = json!({
-            "request": request,
-            "settings": self.settings.clone().unwrap_or_default(),
-        });
-        let validate_str = match serde_json::to_string(&validate_params) {
-            Ok(s) => s,
-            Err(e) => {
-                error!(
-                    error = e.to_string().as_str(),
-                    "cannot serialize validation params"
-                );
-                return ValidationResponse::reject_internal_server_error(uid, e.to_string());
-            }
-        };
-
-        match self.wapc_host.call("validate", validate_str.as_bytes()) {
-            Ok(res) => {
-                let pol_val_resp: Result<PolicyValidationResponse> = serde_json::from_slice(&res)
-                    .map_err(|e| anyhow!("cannot deserialize policy validation response: {:?}", e));
-
-                pol_val_resp
-                    .and_then(|pol_val_resp| {
-                        ValidationResponse::from_policy_validation_response(
-                            uid.clone(),
-                            &req_obj,
-                            &pol_val_resp,
-                        )
-                    })
-                    .unwrap_or_else(|e| {
-                        error!(
-                            error = e.to_string().as_str(),
-                            "cannot build validation response from policy result"
-                        );
-                        ValidationResponse::reject_internal_server_error(uid, e.to_string())
-                    })
-            }
-            Err(e) => {
-                error!(error = e.to_string().as_str(), "waPC communication error");
-
-                ValidationResponse::reject_internal_server_error(uid, e.to_string())
-            }
-        }
-    }
-
     pub fn validate_settings(&self) -> SettingsValidationResponse {
-        let settings_str = match &self.settings {
+        let settings_str = match &self.policy.settings {
             Some(settings) => match serde_json::to_string(settings) {
                 Ok(s) => s,
                 Err(e) => {
@@ -183,5 +288,32 @@ impl PolicyEvaluator {
                 err
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_is_registered_in_the_mapping() -> Result<()> {
+        let policy = Policy::default();
+        let policy_id = 1;
+
+        assert!(!POLICY_MAPPING.read().unwrap().contains_key(&policy_id));
+
+        PolicyEvaluator::from_contents_internal(
+            Vec::new(),
+            || Ok(policy_id),
+            |_, _, _, _| Ok(policy.clone()),
+            None,
+        )?;
+
+        let policy_mapping = POLICY_MAPPING.read().unwrap();
+
+        assert!(policy_mapping.contains_key(&policy_id));
+        assert_eq!(policy_mapping[&policy_id], policy);
+
+        Ok(())
     }
 }

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -144,7 +144,10 @@ impl Default for Metadata {
 
 impl Metadata {
     pub fn from_path(path: &Path) -> Result<Option<Metadata>> {
-        let policy = std::fs::read(path)?;
+        Metadata::from_contents(std::fs::read(path)?)
+    }
+
+    pub fn from_contents(policy: Vec<u8>) -> Result<Option<Metadata>> {
         for payload in Parser::new(0).parse_all(&policy) {
             if let Payload::CustomSection { name, data, .. } = payload? {
                 if name == crate::constants::KUBEWARDEN_CUSTOM_SECTION_METADATA {

--- a/src/policy_tracing.rs
+++ b/src/policy_tracing.rs
@@ -1,0 +1,88 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use tracing::{event, span, Level};
+
+use crate::policy::Policy;
+
+#[derive(Debug, Serialize)]
+enum PolicyLogEntryLevel {
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error,
+}
+
+impl<'de> Deserialize<'de> for PolicyLogEntryLevel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.to_uppercase().as_str() {
+            "TRACE" => Ok(PolicyLogEntryLevel::Trace),
+            "DEBUG" => Ok(PolicyLogEntryLevel::Debug),
+            "INFO" => Ok(PolicyLogEntryLevel::Info),
+            "WARNING" => Ok(PolicyLogEntryLevel::Warning),
+            "ERROR" => Ok(PolicyLogEntryLevel::Error),
+            _ => Err(anyhow!("unknown log level {}", s)).map_err(serde::de::Error::custom),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PolicyLogEntry {
+    level: PolicyLogEntryLevel,
+    message: Option<String>,
+    #[serde(flatten)]
+    data: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+impl Policy {
+    pub(crate) fn log(&self, contents: &[u8]) -> Result<()> {
+        let log_entry: PolicyLogEntry = serde_json::from_slice(&contents)?;
+        let span = span!(
+            parent: &self.span,
+            Level::INFO,
+            "policy",
+            request_uid = tracing::field::Empty,
+            data = %&serde_json::to_string(&log_entry.data.clone().unwrap())?.as_str(),
+        );
+
+        if let Some(request_uid) = &self.request_uid {
+            span.record("request_uid", &request_uid.as_str());
+        }
+
+        macro_rules! log {
+            ($level:path) => {
+                event!(
+                    target: "policy_log",
+                    parent: &span,
+                    $level,
+                    "{}",
+                    log_entry.message.clone().unwrap_or_default()
+                );
+            };
+        }
+
+        match log_entry.level {
+            PolicyLogEntryLevel::Trace => {
+                log!(Level::TRACE);
+            }
+            PolicyLogEntryLevel::Debug => {
+                log!(Level::DEBUG);
+            }
+            PolicyLogEntryLevel::Info => {
+                log!(Level::INFO);
+            }
+            PolicyLogEntryLevel::Warning => {
+                log!(Level::WARN);
+            }
+            PolicyLogEntryLevel::Error => {
+                log!(Level::ERROR);
+            }
+        };
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Implement a waPC `kubewarden.tracing.log` host function.

Co-authored-by: Flavio Castelli <fcastelli@suse.com>