### PR TITLE
Implement Default trait for PolicyExecutionMode

### DIFF
--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -26,6 +26,12 @@ pub enum PolicyExecutionMode {
     OpaGatekeeper,
 }
 
+impl Default for PolicyExecutionMode {
+    fn default() -> Self {
+        PolicyExecutionMode::KubewardenWapc
+    }
+}
+
 lazy_static! {
     static ref WAPC_POLICY_MAPPING: RwLock<HashMap<u64, Policy>> =
         RwLock::new(HashMap::with_capacity(64));

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -130,6 +130,7 @@ pub struct Metadata {
     pub mutating: bool,
     #[serde(default)]
     pub context_aware: bool,
+    #[serde(default)]
     pub execution_mode: PolicyExecutionMode,
 }
 


### PR DESCRIPTION
This is required to automatically fall-back to the Kubewarden evaluation mode when looking at `metadata.yml` files.