### PR TITLE
Update Metadata validation rules

### DIFF
--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -120,8 +120,9 @@ fn validate_resources(data: &[String]) -> Result<(), ValidationError> {
 
 #[derive(Deserialize, Serialize, Debug, Clone, Validate)]
 #[serde(rename_all = "camelCase")]
+#[validate(schema(function = "validate_metadata", skip_on_field_errors = false))]
 pub struct Metadata {
-    #[validate(required, custom = "validate_protocol_version")]
+    #[validate(required)]
     pub protocol_version: Option<ProtocolVersion>,
     #[validate]
     pub rules: Vec<Rule>,
@@ -164,13 +165,15 @@ impl Metadata {
     }
 }
 
-fn validate_protocol_version(protocol: &ProtocolVersion) -> Result<(), ValidationError> {
-    match protocol {
-        ProtocolVersion::Unknown => Err(ValidationError::new(
+fn validate_metadata(metadata: &Metadata) -> Result<(), ValidationError> {
+    if metadata.execution_mode == PolicyExecutionMode::KubewardenWapc
+        && metadata.protocol_version == Some(ProtocolVersion::Unknown)
+    {
+        return Err(ValidationError::new(
             "Must specifify a valid protocol version",
-        )),
-        _ => Ok(()),
+        ));
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -262,7 +265,48 @@ mod tests {
         };
         assert!(metadata.validate().is_err());
 
+        // fails because the protocol cannot be None
+        metadata = Metadata {
+            protocol_version: None,
+            execution_mode: PolicyExecutionMode::KubewardenWapc,
+            ..Default::default()
+        };
+
+        assert!(metadata.validate().is_err());
+
         Ok(())
+    }
+
+    #[test]
+    fn metadata_with_kubewarden_execution_mode_must_have_a_valid_protocol() {
+        let metadata = Metadata {
+            protocol_version: Some(ProtocolVersion::Unknown),
+            execution_mode: PolicyExecutionMode::KubewardenWapc,
+            ..Default::default()
+        };
+
+        assert!(metadata.validate().is_err());
+
+        let metadata = Metadata {
+            protocol_version: Some(ProtocolVersion::V1),
+            execution_mode: PolicyExecutionMode::KubewardenWapc,
+            ..Default::default()
+        };
+
+        assert!(metadata.validate().is_ok());
+    }
+
+    #[test]
+    fn metadata_with_rego_execution_mode_must_have_a_valid_protocol() {
+        for mode in vec![PolicyExecutionMode::Opa, PolicyExecutionMode::OpaGatekeeper] {
+            let metadata = Metadata {
+                protocol_version: Some(ProtocolVersion::Unknown),
+                execution_mode: mode,
+                ..Default::default()
+            };
+
+            assert!(metadata.validate().is_ok());
+        }
     }
 
     #[test]


### PR DESCRIPTION
The Metadata validation rules must take into account how the Opa/Gatekeeper policies behave.

The protocol version is allowed to be "unknown" for them.