### PR TITLE
examples: add basic example rego policies

### DIFF
--- a/crates/burrego/examples/dataless-inputless-bundle/.gitignore
+++ b/crates/burrego/examples/dataless-inputless-bundle/.gitignore
@@ -1,0 +1,2 @@
+*.tar.gz
+*.wasm

--- a/crates/burrego/examples/dataless-inputless-bundle/Makefile
+++ b/crates/burrego/examples/dataless-inputless-bundle/Makefile
@@ -1,0 +1,14 @@
+build: accept.wasm reject.wasm
+
+accept.wasm: accept.rego
+	opa build -t wasm -e policy/main accept.rego -o accept.tar.gz
+	tar -xf accept.tar.gz /policy.wasm
+	mv policy.wasm accept.wasm
+
+reject.wasm: reject.rego
+	opa build -t wasm -e policy/main reject.rego -o reject.tar.gz
+	tar -xf reject.tar.gz /policy.wasm
+	mv policy.wasm reject.wasm
+
+clean:
+	rm -rf *.wasm *.tar.gz

--- a/crates/burrego/examples/dataless-inputless-bundle/accept.rego
+++ b/crates/burrego/examples/dataless-inputless-bundle/accept.rego
@@ -1,0 +1,10 @@
+package policy
+
+main = {
+	"apiVersion": "admission.k8s.io/v1",
+	"kind": "AdmissionReview",
+	"response": {
+		"uid": "705ab4f5-6393-11e8-b7cc-42010a800002",
+		"allowed": true,
+	},
+}

--- a/crates/burrego/examples/dataless-inputless-bundle/reject.rego
+++ b/crates/burrego/examples/dataless-inputless-bundle/reject.rego
@@ -1,0 +1,11 @@
+package policy
+
+main = {
+	"apiVersion": "admission.k8s.io/v1",
+	"kind": "AdmissionReview",
+	"response": {
+		"uid": "705ab4f5-6393-11e8-b7cc-42010a800002",
+		"allowed": false,
+		"status": {"message": "rejection reason coming from the OPA policy"},
+	},
+}


### PR DESCRIPTION
This rego policies have everything hardcoded and do not depend on
`data` nor `input`.