### PR TITLE
Implement callbacks for `opa_abort` and `opa_println` Wasm imports

### DIFF
--- a/crates/burrego/src/opa/default_host_callbacks.rs
+++ b/crates/burrego/src/opa/default_host_callbacks.rs
@@ -1,5 +1,16 @@
 pub(crate) struct DefaultHostCallbacks;
 
+use crate::opa::host_callbacks::HostCallbacks;
+
+impl Default for HostCallbacks {
+    fn default() -> HostCallbacks {
+        HostCallbacks {
+            opa_abort: Box::new(DefaultHostCallbacks::opa_abort),
+            opa_println: Box::new(DefaultHostCallbacks::opa_println),
+        }
+    }
+}
+
 impl DefaultHostCallbacks {
     pub(crate) fn opa_abort(msg: String) {
         println!("OPA abort with message: {:?}", msg);

--- a/crates/burrego/src/opa/host_callbacks.rs
+++ b/crates/burrego/src/opa/host_callbacks.rs
@@ -1,7 +1,5 @@
 use lazy_static::lazy_static;
 
-use crate::opa::default_host_callbacks::DefaultHostCallbacks;
-
 lazy_static! {
     pub static ref DEFAULT_HOST_CALLBACKS: HostCallbacks = HostCallbacks::default();
 }
@@ -17,13 +15,4 @@ pub type HostCallback = Box<dyn Fn(String) + Send + Sync + 'static>;
 pub struct HostCallbacks {
     pub opa_abort: HostCallback,
     pub opa_println: HostCallback,
-}
-
-impl Default for HostCallbacks {
-    fn default() -> HostCallbacks {
-        HostCallbacks {
-            opa_abort: Box::new(DefaultHostCallbacks::opa_abort),
-            opa_println: Box::new(DefaultHostCallbacks::opa_println),
-        }
-    }
 }

--- a/crates/burrego/src/opa/mod.rs
+++ b/crates/burrego/src/opa/mod.rs
@@ -16,6 +16,18 @@ pub struct StackHelper {
     opa_malloc_fn: TypedFunc<i32, i32>,
     opa_json_parse_fn: TypedFunc<(i32, i32), i32>,
     policy_id: usize,
+    // This signals whether the policy invoked the `opa_abort`
+    // import. Right now, we continue execution and don't abort it as
+    // the expectation is, but we use this information to know whether
+    // to return an error result. If `opa_abort` was called, we want
+    // to return an error from the policy execution. We should abort
+    // the execution, but given Rego is not turing-complete, we might
+    // not enter in endless loop due to the the lack of really
+    // aborting the execution.
+    //
+    // TODO (ereslibre): abort execution when `opa_abort` is
+    // called.
+    pub policy_aborted_execution: bool,
 }
 
 impl StackHelper {
@@ -39,6 +51,7 @@ impl StackHelper {
             opa_malloc_fn,
             opa_json_parse_fn,
             policy_id,
+            policy_aborted_execution: false,
         })
     }
 

--- a/src/runtimes/burrego.rs
+++ b/src/runtimes/burrego.rs
@@ -19,13 +19,11 @@ lazy_static! {
 struct BurregoHostCallbacks;
 
 impl BurregoHostCallbacks {
-    fn opa_abort(_msg: String) {
-        // TODO (ereslibre)
-    }
+    #[tracing::instrument(level = "error")]
+    fn opa_abort(msg: String) {}
 
-    fn opa_println(_msg: String) {
-        // TODO (ereslibre)
-    }
+    #[tracing::instrument(level = "info")]
+    fn opa_println(msg: String) {}
 }
 
 impl<'a> Runtime<'a> {


### PR DESCRIPTION
Fixes: https://github.com/kubewarden/policy-evaluator/issues/31
Fixes: https://github.com/kubewarden/policy-evaluator/issues/32

**Note**: I could not find a way to produce Wasm policies that take advantage of this calls. I'm not sure if they are documented because the OPA team wants to implement them in the future, but I could not find a way to produce such a policy so I can test and add tests that validate the implementation.

Implement host callbacks for `opa_abort` and `opa_println` Wasm
imports that Rego policies might invoke when built for the Wasm
target.

- In the `burrego` CLI:

  - `abort` directly calls to `std::process::exit`, aborting the
  program execution.

  - `println` is mapped to what the `println!` macro expands to.

- In the `burrego` runtime backend for the `policy-evaluator`.

  - `abort` sets that the policy has requested abortion on the store,
  and when returning the result, an error is returned. This is doable
  because of the nature of Rego not being Turing complete. Otherwise,
  aborting the execution of the Wasm module on the wasmtime runtime
  environment would be required. In any case, aborting the execution
  would be nice to have and is left as a TODO comment.

  - `println` relies on the `tracing` crate.