### PR TITLE
Opa callbacks

### DIFF
--- a/crates/burrego/src/main.rs
+++ b/crates/burrego/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
             Ok(())
         }
         Some("eval") => {
-            if let Some(ref matches) = matches.subcommand_matches("eval") {
+            if let Some(matches) = matches.subcommand_matches("eval") {
                 if matches.is_present("input") && matches.is_present("input-path") {
                     return Err(anyhow!(
                         "Cannot use 'input' and 'input-path' at the same time"

--- a/crates/burrego/src/opa/default_host_callbacks.rs
+++ b/crates/burrego/src/opa/default_host_callbacks.rs
@@ -14,7 +14,6 @@ impl Default for HostCallbacks {
 impl DefaultHostCallbacks {
     pub(crate) fn opa_abort(msg: String) {
         println!("OPA abort with message: {:?}", msg);
-        std::process::exit(1);
     }
 
     pub(crate) fn opa_println(msg: String) {

--- a/crates/burrego/src/opa/default_host_callbacks.rs
+++ b/crates/burrego/src/opa/default_host_callbacks.rs
@@ -1,5 +1,16 @@
 pub(crate) struct DefaultHostCallbacks;
 
+use crate::opa::host_callbacks::HostCallbacks;
+
+impl Default for HostCallbacks {
+    fn default() -> HostCallbacks {
+        HostCallbacks {
+            opa_abort: Box::new(DefaultHostCallbacks::opa_abort),
+            opa_println: Box::new(DefaultHostCallbacks::opa_println),
+        }
+    }
+}
+
 impl DefaultHostCallbacks {
     pub(crate) fn opa_abort(msg: String) {
         println!("OPA abort with message: {:?}", msg);

--- a/crates/burrego/src/opa/host_callbacks.rs
+++ b/crates/burrego/src/opa/host_callbacks.rs
@@ -1,7 +1,5 @@
 use lazy_static::lazy_static;
 
-use crate::opa::default_host_callbacks::DefaultHostCallbacks;
-
 lazy_static! {
     pub static ref DEFAULT_HOST_CALLBACKS: HostCallbacks = HostCallbacks::default();
 }
@@ -17,13 +15,4 @@ pub type HostCallback = Box<dyn Fn(String) + Send + Sync + 'static>;
 pub struct HostCallbacks {
     pub opa_abort: HostCallback,
     pub opa_println: HostCallback,
-}
-
-impl Default for HostCallbacks {
-    fn default() -> HostCallbacks {
-        HostCallbacks {
-            opa_abort: Box::new(DefaultHostCallbacks::opa_abort),
-            opa_println: Box::new(DefaultHostCallbacks::opa_println),
-        }
-    }
 }

--- a/crates/burrego/src/opa/mod.rs
+++ b/crates/burrego/src/opa/mod.rs
@@ -51,7 +51,7 @@ impl StackHelper {
     /// * The data read
     pub fn read_string(
         &self,
-        store: impl AsContextMut,
+        store: impl AsContext,
         memory: &Memory,
         addr: i32,
     ) -> Result<Vec<u8>> {

--- a/crates/burrego/src/opa/mod.rs
+++ b/crates/burrego/src/opa/mod.rs
@@ -16,6 +16,18 @@ pub struct StackHelper {
     opa_malloc_fn: TypedFunc<i32, i32>,
     opa_json_parse_fn: TypedFunc<(i32, i32), i32>,
     policy_id: usize,
+    // This signals whether the policy invoked the `opa_abort`
+    // import. Right now, we continue execution and don't abort it as
+    // the expectation is, but we use this information to know whether
+    // to return an error result. If `opa_abort` was called, we want
+    // to return an error from the policy execution. We should abort
+    // the execution, but given Rego is not turing-complete, we might
+    // not enter in endless loop due to the the lack of really
+    // aborting the execution.
+    //
+    // TODO (ereslibre): abort execution when `opa_abort` is
+    // called.
+    pub policy_aborted_execution: bool,
 }
 
 impl StackHelper {
@@ -39,6 +51,7 @@ impl StackHelper {
             opa_malloc_fn,
             opa_json_parse_fn,
             policy_id,
+            policy_aborted_execution: false,
         })
     }
 

--- a/crates/burrego/src/opa/mod.rs
+++ b/crates/burrego/src/opa/mod.rs
@@ -55,6 +55,34 @@ impl StackHelper {
         })
     }
 
+    /// Read a string from the Wasm guest into the host
+    /// # Arguments
+    /// * `store` - the Store associated with the Wasm instance
+    /// * `memory` - the Wasm linear memory used by the Wasm Instance
+    /// * `addr` - address inside of the Wasm linear memory where the value is stored
+    /// # Returns
+    /// * The data read
+    pub fn read_string(
+        &self,
+        store: impl AsContextMut,
+        memory: &Memory,
+        addr: i32,
+    ) -> Result<Vec<u8>> {
+        let mut buffer: [u8; 1] = [0u8];
+        let mut data: Vec<u8> = vec![];
+        let mut raw_addr = addr;
+
+        loop {
+            memory.read(&store, raw_addr.try_into().unwrap(), &mut buffer)?;
+            if buffer[0] == 0 {
+                break;
+            }
+            data.push(buffer[0]);
+            raw_addr += 1;
+        }
+        Ok(data)
+    }
+
     /// Pull a JSON data from the Wasm guest into the host
     /// # Arguments
     /// * `store` - the Store associated with the Wasm instance
@@ -68,18 +96,8 @@ impl StackHelper {
         memory: &Memory,
         addr: i32,
     ) -> Result<serde_json::Value> {
-        let mut raw_addr = self.opa_json_dump_fn.call(store.as_context_mut(), addr)?;
-        let mut buffer: [u8; 1] = [0u8];
-        let mut data: Vec<u8> = vec![];
-
-        loop {
-            memory.read(&store, raw_addr.try_into().unwrap(), &mut buffer)?;
-            if buffer[0] == 0 {
-                break;
-            }
-            data.push(buffer[0]);
-            raw_addr += 1;
-        }
+        let raw_addr = self.opa_json_dump_fn.call(store.as_context_mut(), addr)?;
+        let data = self.read_string(store, memory, raw_addr)?;
 
         serde_json::from_slice(&data).map_err(|e| {
             anyhow!(

--- a/crates/burrego/src/opa/mod.rs
+++ b/crates/burrego/src/opa/mod.rs
@@ -16,18 +16,6 @@ pub struct StackHelper {
     opa_malloc_fn: TypedFunc<i32, i32>,
     opa_json_parse_fn: TypedFunc<(i32, i32), i32>,
     policy_id: usize,
-    // This signals whether the policy invoked the `opa_abort`
-    // import. Right now, we continue execution and don't abort it as
-    // the expectation is, but we use this information to know whether
-    // to return an error result. If `opa_abort` was called, we want
-    // to return an error from the policy execution. We should abort
-    // the execution, but given Rego is not turing-complete, we might
-    // not enter in endless loop due to the the lack of really
-    // aborting the execution.
-    //
-    // TODO (ereslibre): abort execution when `opa_abort` is
-    // called.
-    pub policy_aborted_execution: bool,
 }
 
 impl StackHelper {
@@ -51,7 +39,6 @@ impl StackHelper {
             opa_malloc_fn,
             opa_json_parse_fn,
             policy_id,
-            policy_aborted_execution: false,
         })
     }
 

--- a/crates/burrego/src/opa/wasm.rs
+++ b/crates/burrego/src/opa/wasm.rs
@@ -126,9 +126,12 @@ impl Evaluator {
                 let mut stack_helper = caller.data_mut().unwrap();
                 stack_helper.policy_aborted_execution = true;
                 let msg = stack_helper
-                    .pull_json(caller.as_context_mut(), &memory, addr)
-                    .unwrap();
-                (host_callbacks.opa_abort)(msg.to_string());
+                    .read_string(caller.as_context_mut(), &memory, addr)
+                    .map_or_else(
+                        |e| format!("cannot decode abort message: {:?}", e),
+                        |data| String::from_utf8(data).unwrap_or_else(|e| format!("cannot decode abort message: didn't read a valid string from memory - {:?}", e)),
+                    );
+                (host_callbacks.opa_abort)(msg);
             },
         );
         linker.define("env", "opa_abort", opa_abort)?;

--- a/crates/burrego/src/opa/wasm.rs
+++ b/crates/burrego/src/opa/wasm.rs
@@ -127,8 +127,8 @@ impl Evaluator {
                 let msg = stack_helper
                     .read_string(caller.as_context_mut(), &memory, addr)
                     .map_or_else(
-                        |e| format!("cannot decode abort message: {:?}", e),
-                        |data| String::from_utf8(data).unwrap_or_else(|e| format!("cannot decode abort message: didn't read a valid string from memory - {:?}", e)),
+                        |e| format!("cannot decode opa_abort message: {:?}", e),
+                        |data| String::from_utf8(data).unwrap_or_else(|e| format!("cannot decode opa_abort message: didn't read a valid string from memory - {:?}", e)),
                     );
                 (host_callbacks.opa_abort)(msg);
             },
@@ -140,9 +140,12 @@ impl Evaluator {
             move |mut caller: Caller<'_, Option<StackHelper>>, addr: i32| {
                 let stack_helper = caller.data_mut().unwrap();
                 let msg = stack_helper
-                    .pull_json(caller.as_context_mut(), &memory, addr)
-                    .unwrap();
-                (host_callbacks.opa_println)(msg.to_string());
+                    .read_string(caller.as_context_mut(), &memory, addr)
+                    .map_or_else(
+                        |e| format!("cannot decode opa_println message: {:?}", e),
+                        |data| String::from_utf8(data).unwrap_or_else(|e| format!("cannot decode opa_println message: didn't read a valid string from memory - {:?}", e)),
+                    );
+                (host_callbacks.opa_println)(msg);
             },
         );
         linker.define("env", "opa_println", opa_println)?;

--- a/crates/burrego/src/opa/wasm.rs
+++ b/crates/burrego/src/opa/wasm.rs
@@ -123,8 +123,7 @@ impl Evaluator {
         let opa_abort = Func::wrap(
             &mut store,
             move |mut caller: Caller<'_, Option<StackHelper>>, addr: i32| {
-                let mut stack_helper = caller.data_mut().unwrap();
-                stack_helper.policy_aborted_execution = true;
+                let stack_helper = caller.data().unwrap();
                 let msg = stack_helper
                     .read_string(caller.as_context_mut(), &memory, addr)
                     .map_or_else(
@@ -443,11 +442,7 @@ impl Evaluator {
         let res = self
             .policy
             .evaluate(entrypoint_id, &mut self.store, &self.memory, input)
-            .map_err(|e| anyhow!("Cannot convert evaluation result back to JSON: {:?}", e));
-
-        if self.store.data().unwrap().policy_aborted_execution {
-            return Err(anyhow!("The OPA policy aborted execution"));
-        }
+            .map_err(|e| anyhow!("Evaluation error: {:?}", e));
 
         res
     }

--- a/crates/burrego/src/opa/wasm.rs
+++ b/crates/burrego/src/opa/wasm.rs
@@ -442,11 +442,8 @@ impl Evaluator {
             input = serde_json::to_string(&input)?.as_str(),
             "attempting evaluation"
         );
-        let res = self
-            .policy
+        self.policy
             .evaluate(entrypoint_id, &mut self.store, &self.memory, input)
-            .map_err(|e| anyhow!("Evaluation error: {:?}", e));
-
-        res
+            .map_err(|e| anyhow!("Evaluation error: {:?}", e))
     }
 }

--- a/src/runtimes/burrego.rs
+++ b/src/runtimes/burrego.rs
@@ -19,13 +19,11 @@ lazy_static! {
 struct BurregoHostCallbacks;
 
 impl BurregoHostCallbacks {
-    fn opa_abort(_msg: String) {
-        // TODO (ereslibre)
-    }
+    #[tracing::instrument(level = "error")]
+    fn opa_abort(msg: String) {}
 
-    fn opa_println(_msg: String) {
-        // TODO (ereslibre)
-    }
+    #[tracing::instrument(level = "info")]
+    fn opa_println(msg: String) {}
 }
 
 impl<'a> Runtime<'a> {


### PR DESCRIPTION
This PR is built on top of https://github.com/kubewarden/policy-evaluator/pull/34 and supersede it.

Differences introduced by this PR:

* `opa_abort`
  * Fix how the error message of `opa_abort` is retrieved from the Wasm memory
  * Do not cause the running process to exit immediately with an error. An `Err` is automatically raised by Wasmtime. The same Wasmtime stack (engine, instance, memory,...) can be reused to process more requests