### PR TITLE
Expose "get OCI manifest digest" callback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,11 @@ k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_22
 kube = { version = "0.64.0", default-features = false, features = ["client", "rustls-tls"] }
 kubewarden-policy-sdk = "0.2.2"
 lazy_static = "1.4.0"
+oci-distribution = { git = "https://github.com/krustlet/oci-distribution", rev = "96f19570e7f9dd56ed9cce8c9e8095e7c2d7753b" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.2.2" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 validator = { version = "0.13", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
 anyhow = "1.0"
 base64 = "0.13.0"
 burrego = { path = "crates/burrego" }
+cached = "0.26.2"
 hyper = { version = "0.14" }
 json-patch = "0.2.6"
 k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_22"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.2.5"
+version = "0.2.6"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -104,6 +104,11 @@ impl CallbackHandler {
     pub async fn loop_eval(&mut self) {
         loop {
             tokio::select! {
+                // place the shutdown check before the message evaluation,
+                // as recommended by tokio's documentation about select!
+                _ = &mut self.shutdown_channel => {
+                    return;
+                },
                 maybe_req = self.rx.recv() => {
                     if let Some(req) = maybe_req {
                         match req.request {
@@ -129,9 +134,6 @@ impl CallbackHandler {
                         }
                     }
                 },
-                _ = &mut self.shutdown_channel => {
-                    return;
-                }
             }
         }
     }

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -1,0 +1,133 @@
+use anyhow::{anyhow, Result};
+use policy_fetcher::{registry::config::DockerConfig, sources::Sources};
+use tokio::sync::{mpsc, oneshot};
+use tracing::warn;
+
+use crate::callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse};
+
+mod oci;
+
+const DEFAULT_CHANNEL_BUFF_SIZE: usize = 100;
+
+/// Helper struct that creates CallbackHandler objects
+pub struct CallbackHandlerBuilder {
+    oci_sources: Option<Sources>,
+    docker_config: Option<DockerConfig>,
+    channel_buffer_size: usize,
+    shutdown_channel: Option<oneshot::Receiver<()>>,
+}
+
+impl Default for CallbackHandlerBuilder {
+    fn default() -> Self {
+        CallbackHandlerBuilder {
+            oci_sources: None,
+            docker_config: None,
+            shutdown_channel: None,
+            channel_buffer_size: DEFAULT_CHANNEL_BUFF_SIZE,
+        }
+    }
+}
+
+impl CallbackHandlerBuilder {
+    #![allow(dead_code)]
+
+    /// Provide all the information needed to access OCI registries. Optional
+    pub fn registry_config(
+        mut self,
+        sources: Option<Sources>,
+        docker_config: Option<DockerConfig>,
+    ) -> Self {
+        self.oci_sources = sources;
+        self.docker_config = docker_config;
+        self
+    }
+
+    /// Set the size of the channel used by the sync world to communicate with
+    /// the CallbackHandler. Optional
+    pub fn channel_buffer_size(mut self, size: usize) -> Self {
+        self.channel_buffer_size = size;
+        self
+    }
+
+    /// Set the onetime channel used to stop the endless loop of
+    /// CallbackHandler. Mandatory
+    pub fn shutdown_channel(mut self, shutdown_channel: oneshot::Receiver<()>) -> Self {
+        self.shutdown_channel = Some(shutdown_channel);
+        self
+    }
+
+    /// Create a CallbackHandler object
+    pub fn build(self) -> Result<CallbackHandler> {
+        let (tx, rx) = mpsc::channel::<CallbackRequest>(self.channel_buffer_size);
+        if self.shutdown_channel.is_none() {
+            return Err(anyhow!("shutdown_channel_rx not provided"));
+        }
+
+        let oci_client = oci::Client::new(self.oci_sources, self.docker_config);
+        Ok(CallbackHandler {
+            oci_client,
+            tx,
+            rx,
+            shutdown_channel: self.shutdown_channel.unwrap(),
+        })
+    }
+}
+
+/// Struct that computes request coming from a Wasm guest.
+/// This should be used only to handle the requests that need some async
+/// code in order to be fulfilled.
+pub struct CallbackHandler {
+    oci_client: oci::Client,
+    rx: mpsc::Receiver<CallbackRequest>,
+    tx: mpsc::Sender<CallbackRequest>,
+    shutdown_channel: oneshot::Receiver<()>,
+}
+
+impl CallbackHandler {
+    /// Returns the sender side of the channel that can be used by the sync code
+    /// (like the `host_callback` function of PolicyEvaluator)
+    /// to request the computation of async code.
+    ///
+    /// Can be invoked as many times as wanted.
+    pub fn sender_channel(&self) -> mpsc::Sender<CallbackRequest> {
+        self.tx.clone()
+    }
+
+    /// Enter an endless loop that:
+    ///    1. Waits for requests to be evaluated
+    ///    2. Evaluate the request
+    ///    3. Send back the result of the evaluation
+    ///
+    /// The loop is interrupted only when a message is sent over the
+    /// `shutdown_channel`.
+    pub async fn loop_eval(&mut self) {
+        loop {
+            tokio::select! {
+                maybe_req = self.rx.recv() => {
+                    if let Some(req) = maybe_req {
+                        match req.request {
+                            CallbackRequestType::OciManifestDigest {
+                                image,
+                            } => {
+                                let response =
+                                    self.oci_client
+                                        .digest(&image)
+                                        .await
+                                        .map(|digest| CallbackResponse {
+                                            payload: digest.as_bytes().to_vec(),
+                                        });
+
+                                if let Err(e) = req.response_channel.send(response) {
+                                    warn!("callback handler: cannot send response back: {:?}", e);
+                                }
+                            }
+                        }
+                    }
+                },
+                _ = &mut self.shutdown_channel => {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/callback_handler/oci.rs
+++ b/src/callback_handler/oci.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+use policy_fetcher::{registry::config::DockerConfig, registry::Registry, sources::Sources};
+
+/// Helper struct to interact with an OCI registry
+pub(crate) struct Client {
+    sources: Option<Sources>,
+    registry: Registry,
+}
+
+impl Client {
+    pub fn new(sources: Option<Sources>, docker_config: Option<DockerConfig>) -> Self {
+        let registry = Registry::new(docker_config.as_ref());
+        Client { sources, registry }
+    }
+
+    /// Fetch the manifest digest of the OCI resource referenced via `image`
+    pub async fn digest(&self, image: &str) -> Result<String> {
+        let image_with_proto = format!("registry://{}", image);
+        self.registry
+            .manifest_digest(&image_with_proto, self.sources.as_ref())
+            .await
+    }
+}

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -11,13 +11,21 @@ pub struct CallbackResponse {
 /// Describes the different kinds of request a waPC guest can make to
 /// our host.
 #[derive(Debug)]
-pub enum CallbackRequest {
+pub enum CallbackRequestType {
     /// Require the computation of the manifest digest of an OCI object (be
     /// it an image or anything else that can be stored into an OCI registry)
     OciManifestDigest {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
-        /// A tokio oneshot channel over which the evaluation response has to be sent
-        response_channel: oneshot::Sender<Result<CallbackResponse>>,
     },
+}
+
+/// A request sent by some synchronous code (usually waPC's host_callback)
+/// that can be evaluated only inside of asynchronous code.
+#[derive(Debug)]
+pub struct CallbackRequest {
+    /// The actual request to be evaluated
+    pub request: CallbackRequestType,
+    /// A tokio oneshot channel over which the evaluation response has to be sent
+    pub response_channel: oneshot::Sender<Result<CallbackResponse>>,
 }

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -15,7 +15,7 @@ pub enum CallbackRequest {
     /// Require the computation of the manifest digest of an OCI object (be
     /// it an image or anything else that can be stored into an OCI registry)
     OciManifestDigest {
-        /// String pointing to the object (e.g.: `resitry.testing.lan/busybox:1.0.0`)
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
         /// A tokio oneshot channel over which the evaluation response has to be sent
         response_channel: oneshot::Sender<Result<CallbackResponse>>,

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+use tokio::sync::oneshot;
+
+/// Holds the response to a waPC evaluation request
+#[derive(Debug)]
+pub struct CallbackResponse {
+    /// The data to be given back to the waPC guest
+    pub payload: Vec<u8>,
+}
+
+/// Describes the different kinds of request a waPC guest can make to
+/// our host.
+#[derive(Debug)]
+pub enum CallbackRequest {
+    /// Require the computation of the manifest digest of an OCI object (be
+    /// it an image or anything else that can be stored into an OCI registry)
+    OciManifestDigest {
+        /// String pointing to the object (e.g.: `resitry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// A tokio oneshot channel over which the evaluation response has to be sent
+        response_channel: oneshot::Sender<Result<CallbackResponse>>,
+    },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate k8s_openapi;
 extern crate kube;
 extern crate wasmparser;
 
+pub mod callback_handler;
 pub mod callback_requests;
 pub mod cluster_context;
 pub mod constants;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,12 @@ extern crate k8s_openapi;
 extern crate kube;
 extern crate wasmparser;
 
+pub mod callback_requests;
 pub mod cluster_context;
 pub mod constants;
 pub(crate) mod policy;
 pub mod policy_evaluator;
+pub mod policy_evaluator_builder;
 pub mod policy_metadata;
 mod policy_tracing;
 pub mod runtimes;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::clone::Clone;
+use std::fmt;
 use tokio::sync::mpsc;
 
 use crate::callback_requests::CallbackRequest;
@@ -10,7 +11,7 @@ use crate::callback_requests::CallbackRequest;
 /// This struct is used extensively inside of the `host_callback`
 /// function to obtain information about the policy that is invoking
 /// a host waPC function, and handle the request.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Policy {
     pub id: String,
     policy_id: Option<u64>,
@@ -18,6 +19,21 @@ pub struct Policy {
     /// to request the computation of code that can only be run inside of an
     /// asynchronous block
     pub callback_channel: Option<mpsc::Sender<CallbackRequest>>,
+}
+
+impl fmt::Debug for Policy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let callback_channel = match self.callback_channel {
+            Some(_) => "Some(...)",
+            None => "None",
+        };
+
+        write!(
+            f,
+            r#"Policy {{ id: "{}", policy_id: {:?}, callback_channel: {} }}"#,
+            self.id, self.policy_id, callback_channel,
+        )
+    }
 }
 
 impl PartialEq for Policy {

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,10 +1,29 @@
 use anyhow::Result;
 use std::clone::Clone;
+use tokio::sync::mpsc;
 
-#[derive(Clone, Debug, PartialEq)]
+use crate::callback_requests::CallbackRequest;
+
+/// Minimal amount of information about a policy that need to
+/// be always accessible at runtime.
+///
+/// This struct is used extensively inside of the `host_callback`
+/// function to obtain information about the policy that is invoking
+/// a host waPC function, and handle the request.
+#[derive(Clone, Debug)]
 pub struct Policy {
     pub id: String,
     policy_id: Option<u64>,
+    /// Channel used by the synchronous world (the `host_callback` waPC function),
+    /// to request the computation of code that can only be run inside of an
+    /// asynchronous block
+    pub callback_channel: Option<mpsc::Sender<CallbackRequest>>,
+}
+
+impl PartialEq for Policy {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.policy_id == other.policy_id
+    }
 }
 
 #[cfg(test)]
@@ -13,12 +32,21 @@ impl Default for Policy {
         Policy {
             id: String::default(),
             policy_id: None,
+            callback_channel: None,
         }
     }
 }
 
 impl Policy {
-    pub(crate) fn new(id: String, policy_id: Option<u64>) -> Result<Policy> {
-        Ok(Policy { id, policy_id })
+    pub(crate) fn new(
+        id: String,
+        policy_id: Option<u64>,
+        callback_channel: Option<mpsc::Sender<CallbackRequest>>,
+    ) -> Result<Policy> {
+        Ok(Policy {
+            id,
+            policy_id,
+            callback_channel,
+        })
     }
 }

--- a/src/policy_evaluator_builder.rs
+++ b/src/policy_evaluator_builder.rs
@@ -1,0 +1,106 @@
+use anyhow::{anyhow, Result};
+use std::{fs, path::Path};
+use tokio::sync::mpsc::Sender;
+
+use crate::callback_requests::CallbackRequest;
+use crate::policy_evaluator::{PolicyEvaluator, PolicyExecutionMode};
+
+/// Helper Struct that creates a `PolicyEvaluator` object
+#[derive(Default)]
+pub struct PolicyEvaluatorBuilder {
+    policy_id: String,
+    policy_file: Option<String>,
+    policy_contents: Option<Vec<u8>>,
+    execution_mode: Option<PolicyExecutionMode>,
+    settings: Option<serde_json::Map<String, serde_json::Value>>,
+    callback_channel: Option<Sender<CallbackRequest>>,
+}
+
+impl PolicyEvaluatorBuilder {
+    /// Create a new PolicyEvaluatorBuilder object. The `policy_id` must be
+    /// specified.
+    pub fn new(policy_id: String) -> PolicyEvaluatorBuilder {
+        PolicyEvaluatorBuilder {
+            policy_id,
+            ..Default::default()
+        }
+    }
+
+    /// Build the policy by reading the Wasm file from disk.
+    /// Cannot be used at the same time as `policy_contents`
+    pub fn policy_file(mut self, path: &Path) -> Result<PolicyEvaluatorBuilder> {
+        let filename = path
+            .to_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow!("Cannot convert given path to String"))?;
+        self.policy_file = Some(filename);
+        Ok(self)
+    }
+
+    /// Build the policy by using the Wasm object given via the `data` array.
+    /// Cannot be used at the same time as `policy_file`
+    pub fn policy_contents(mut self, data: &[u8]) -> PolicyEvaluatorBuilder {
+        self.policy_contents = Some(data.to_owned());
+        self
+    }
+
+    /// Sets the policy execution mode
+    pub fn execution_mode(mut self, mode: PolicyExecutionMode) -> PolicyEvaluatorBuilder {
+        self.execution_mode = Some(mode);
+        self
+    }
+
+    /// Set the settings the policy will use at evaluation time
+    pub fn settings(
+        mut self,
+        s: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> PolicyEvaluatorBuilder {
+        self.settings = s;
+        self
+    }
+
+    /// Specify the channel that is used by the synchronous world (the waPC `host_callback`
+    /// function) to obtain information that can be computed only from within a
+    /// tokio runtime.
+    ///
+    /// Note well: if no channel is given, the policy will still be created, but
+    /// some waPC functions exposed by the host will not be available at runtime.
+    /// The policy evaluation will not fail because of that, but the guest will
+    /// get an error instead of the expected result.
+    pub fn callback_channel(mut self, channel: Sender<CallbackRequest>) -> PolicyEvaluatorBuilder {
+        self.callback_channel = Some(channel);
+        self
+    }
+
+    /// Create the instance of `PolicyEvaluator` to be used
+    pub fn build(self) -> Result<PolicyEvaluator> {
+        if self.policy_file.is_some() && self.policy_contents.is_some() {
+            return Err(anyhow!(
+                "Cannot specify 'policy_file' and 'policy_contents' at the same time"
+            ));
+        }
+        if self.policy_file.is_none() && self.policy_contents.is_none() {
+            return Err(anyhow!(
+                "Must specify either 'policy_file' or 'policy_contents'"
+            ));
+        }
+        let contents: Vec<u8> = if let Some(file) = self.policy_file {
+            fs::read(file.clone())
+                .map_err(|e| anyhow!("Cannot read policy from file {}: {:?}", file, e))?
+        } else {
+            self.policy_contents.unwrap()
+        };
+
+        let mode = self
+            .execution_mode
+            .ok_or_else(|| anyhow!("Must specify execution mode"))?;
+
+        PolicyEvaluator::new(
+            self.policy_id,
+            contents,
+            mode,
+            self.settings,
+            self.callback_channel,
+        )
+    }
+}

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -7,7 +7,7 @@ use tracing::{debug, error};
 
 pub(crate) struct Runtime<'a>(pub(crate) &'a mut wapc::WapcHost);
 
-use crate::callback_requests::{CallbackRequest, CallbackResponse};
+use crate::callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse};
 use crate::cluster_context::ClusterContext;
 use crate::policy::Policy;
 use crate::policy_evaluator::{PolicySettings, ValidateRequest};
@@ -75,8 +75,10 @@ pub(crate) fn host_callback(
                         .map_err(|_| "Cannot parse given payload as string")?;
 
                     let (tx, mut rx) = oneshot::channel::<Result<CallbackResponse>>();
-                    let req = CallbackRequest::OciManifestDigest {
-                        image: image.clone(),
+                    let req = CallbackRequest {
+                        request: CallbackRequestType::OciManifestDigest {
+                            image: image.clone(),
+                        },
                         response_channel: tx,
                     };
 

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -2,10 +2,12 @@ use anyhow::{anyhow, Result};
 use lazy_static::lazy_static;
 use serde_json::json;
 use std::{collections::HashMap, convert::TryFrom, sync::RwLock};
-use tracing::error;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, error};
 
 pub(crate) struct Runtime<'a>(pub(crate) &'a mut wapc::WapcHost);
 
+use crate::callback_requests::{CallbackRequest, CallbackResponse};
 use crate::cluster_context::ClusterContext;
 use crate::policy::Policy;
 use crate::policy_evaluator::{PolicySettings, ValidateRequest};
@@ -43,6 +45,90 @@ pub(crate) fn host_callback(
                         );
                     }
                     Ok(Vec::new())
+                }
+                _ => {
+                    error!(namespace, operation, "unknown operation");
+                    Err(format!("unknown operation: {}", operation).into())
+                }
+            },
+            "oci" => match operation {
+                "manifest_digest" => {
+                    let policy_mapping = WAPC_POLICY_MAPPING.read().unwrap();
+                    let policy = policy_mapping.get(&policy_id).unwrap();
+
+                    let cb_channel: mpsc::Sender<CallbackRequest> =
+                        if let Some(c) = policy.callback_channel.clone() {
+                            Ok(c)
+                        } else {
+                            error!(
+                                policy_id,
+                                binding,
+                                operation,
+                                "Cannot process waPC request: callback channel not provided"
+                            );
+                            Err(anyhow!(
+                                "Cannot process waPC request: callback channel not provided"
+                            ))
+                        }?;
+
+                    let image = String::from_utf8(payload.to_vec())
+                        .map_err(|_| "Cannot parse given payload as string")?;
+
+                    let (tx, mut rx) = oneshot::channel::<Result<CallbackResponse>>();
+                    let req = CallbackRequest::OciManifestDigest {
+                        image: image.clone(),
+                        response_channel: tx,
+                    };
+
+                    debug!(
+                        policy_id,
+                        binding,
+                        operation,
+                        image = image.as_str(),
+                        "Sending request via callback channel"
+                    );
+                    let send_result = cb_channel.try_send(req);
+                    if let Err(e) = send_result {
+                        return Err(format!(
+                            "Error sending request over callback channel: {:?}",
+                            e
+                        )
+                        .into());
+                    }
+
+                    // wait for the response
+                    loop {
+                        match rx.try_recv() {
+                            Ok(msg) => {
+                                return match msg {
+                                    Ok(resp) => Ok(resp.payload),
+                                    Err(e) => {
+                                        error!(
+                                            policy_id,
+                                            binding,
+                                            operation,
+                                            error = e.to_string().as_str(),
+                                            "callback evaluation failed"
+                                        );
+                                        Err(format!("Callback evaluation failure: {:?}", e).into())
+                                    }
+                                }
+                            }
+                            Err(oneshot::error::TryRecvError::Empty) => {
+                                //  do nothing, keep waiting for a reply
+                            }
+                            Err(e) => {
+                                error!(
+                                    policy_id,
+                                    binding,
+                                    operation,
+                                    error = e.to_string().as_str(),
+                                    "Cannot process waPC request: error obtaining response over callback channel"
+                                );
+                                return Err("Error obtaining response over callback channel".into());
+                            }
+                        }
+                    }
                 }
                 _ => {
                     error!("unknown operation: {}", operation);


### PR DESCRIPTION
Expose the get OCI manifest digest callback

Allow the Wasm guests to obtain the manifest's digest of
an OCI object (be it a container or an artifact).

Fetching information from a OCI registry requires the execution
of asynchronous code. Unfortunately the `host_callback` function
is a synchronous function.

Creating a dedicated tokio runtime (even by reusing the "current thread"
of the `host_callback` function) is not going to work. This would cause
tokio to cause a `panic` at runtime.

The solution of this problem consists of using a tokio channel that can
send the evaluation request from the synchronous world (the `host_callback`
function) to an `asynchronous` "worker" (something created with a tokio
`spawn` for example).

The response from the asynchronous world is then sent back to the
synchronous one by using a dedicated tokio `oneshot` channel.

## Changes

On top of exposing the new waPC host function, and adding all the tokio
channels. The following changes have been done:

  * The creation of a `PolicyEvaluator` is now done by using a dedicated
    builder: `PolicyEvaluatorBuilder`.
  * The code executing `PolicyEvaluator` (kwctl, policy-server) must
    prepare the worker that can handle the evaluation requests coming
    from the waPC guests.
