### PR TITLE
Mutating field.

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -14,6 +14,7 @@ use crate::callback_requests::CallbackRequest;
 #[derive(Clone)]
 pub struct Policy {
     pub id: String,
+    pub mutating: bool,
     policy_id: Option<u64>,
     /// Channel used by the synchronous world (the `host_callback` waPC function),
     /// to request the computation of code that can only be run inside of an
@@ -56,11 +57,13 @@ impl Default for Policy {
 impl Policy {
     pub(crate) fn new(
         id: String,
+        mutating: bool,
         policy_id: Option<u64>,
         callback_channel: Option<mpsc::Sender<CallbackRequest>>,
     ) -> Result<Policy> {
         Ok(Policy {
             id,
+            mutating,
             policy_id,
             callback_channel,
         })

--- a/src/policy_evaluator_builder.rs
+++ b/src/policy_evaluator_builder.rs
@@ -9,6 +9,7 @@ use crate::policy_evaluator::{PolicyEvaluator, PolicyExecutionMode};
 #[derive(Default)]
 pub struct PolicyEvaluatorBuilder {
     policy_id: String,
+    mutating: bool,
     policy_file: Option<String>,
     policy_contents: Option<Vec<u8>>,
     execution_mode: Option<PolicyExecutionMode>,
@@ -19,9 +20,10 @@ pub struct PolicyEvaluatorBuilder {
 impl PolicyEvaluatorBuilder {
     /// Create a new PolicyEvaluatorBuilder object. The `policy_id` must be
     /// specified.
-    pub fn new(policy_id: String) -> PolicyEvaluatorBuilder {
+    pub fn new(policy_id: String, mutating: bool) -> PolicyEvaluatorBuilder {
         PolicyEvaluatorBuilder {
             policy_id,
+            mutating,
             ..Default::default()
         }
     }
@@ -97,6 +99,7 @@ impl PolicyEvaluatorBuilder {
 
         PolicyEvaluator::new(
             self.policy_id,
+            self.mutating,
             contents,
             mode,
             self.settings,


### PR DESCRIPTION
Adds the "mutating" field in the policy type to allow policy server checking if the policy evaluated is allowed to mutate the requests.