### PR TITLE
Expose `policy-fetcher` through `policy-evaluator`

### DIFF
--- a/crates/burrego/src/main.rs
+++ b/crates/burrego/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use clap::{crate_authors, crate_name, crate_version, App, AppSettings, Arg};
+use clap::{crate_authors, crate_name, crate_version, Arg, Command};
 use serde_json::json;
 use std::{fs::File, io::BufReader, path::PathBuf, process};
 
@@ -10,8 +10,8 @@ use tracing_subscriber::{fmt, EnvFilter};
 mod opa;
 use opa::wasm::Evaluator;
 
-pub(crate) fn build_cli() -> App<'static> {
-    App::new(crate_name!())
+pub(crate) fn build_cli() -> Command<'static> {
+    Command::new(crate_name!())
         .author(crate_authors!())
         .version(crate_version!())
         .about("evaluate a OPA policy")
@@ -22,7 +22,7 @@ pub(crate) fn build_cli() -> App<'static> {
                 .help("Increase verbosity"),
         )
         .subcommand(
-            App::new("eval")
+            Command::new("eval")
                 .about("evaluate a OPA policy")
                 .arg(
                     Arg::new("input")
@@ -58,8 +58,8 @@ pub(crate) fn build_cli() -> App<'static> {
                         .help("Path to the wasm file containing the policy"),
                 ),
         )
-        .subcommand(App::new("builtins").about("List the supported builtins"))
-        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(Command::new("builtins").about("List the supported builtins"))
+        .arg_required_else_help(true)
 }
 
 fn main() -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,15 @@ mod policy_tracing;
 pub mod runtimes;
 pub mod validation_response;
 
+// API's that expose other crate types (such as Kubewarden Policy SDK
+// or `policy_fetcher`) can either implement their own exposed types,
+// and means to convert those types internally to their dependencies
+// types, or depending on the specific case, re-export dependencies
+// API's directly.
+//
+// Re-exporting specific crates that belong to us is easier for common
+// consumers of these libraries along with the `policy-evaluator`, so
+// they can access these crates through the `policy-evaluator` itself,
+// streamlining their dependencies as well.
 pub use kubewarden_policy_sdk::metadata::ProtocolVersion;
+pub use policy_fetcher;


### PR DESCRIPTION
This makes easier for consumers of both crates (e.g. `kwctl` and
`policy-server`) to consume types and traits that are common to
both (given that `policy-evaluator` also depends on `policy-fetcher`).