### PR TITLE
burrego: expose the `entrypoints` API

### DIFF
--- a/crates/burrego/src/main.rs
+++ b/crates/burrego/src/main.rs
@@ -125,6 +125,9 @@ fn main() -> Result<()> {
                 let (major, minor) = evaluator.opa_abi_version()?;
                 debug!(major, minor, "OPA Wasm ABI");
 
+                let entrypoints = evaluator.entrypoints()?;
+                debug!(?entrypoints, "OPA entrypoints");
+
                 let not_implemented_builtins = evaluator.not_implemented_builtins()?;
                 if !not_implemented_builtins.is_empty() {
                     eprintln!("Cannot evaluate policy, these builtins are not yet implemented:");

--- a/crates/burrego/src/opa/wasm.rs
+++ b/crates/burrego/src/opa/wasm.rs
@@ -425,6 +425,10 @@ impl Evaluator {
             })
     }
 
+    pub fn entrypoints(&mut self) -> Result<HashMap<String, i32>> {
+        self.policy.entrypoints(&mut self.store, &self.memory)
+    }
+
     pub fn evaluate(
         &mut self,
         entrypoint_id: i32,


### PR DESCRIPTION
This is required to dump the list of entrypoints a Rego Wasm module has.
