### PR TITLE
feat: Allow policy authors to write policies that perform image verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ wasmparser = "0.82.0"
 # version of `wapc` has been pushed to crates.io.
 wapc = { git = "https://github.com/wapc/wapc-rs", tag = "wapc@1.0.0-alpha.1" }
 wasmtime-provider = { git = "https://github.com/wapc/wapc-rs", tag = "wapc@1.0.0-alpha.1" }
+url = "2.2.2"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -1,12 +1,8 @@
 use anyhow::{anyhow, Result};
-use olpc_cjson::CanonicalFormatter;
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::LatestVerificationConfig;
 use policy_fetcher::registry::config::DockerConfig;
 use policy_fetcher::sources::Sources;
 use policy_fetcher::verify::{FulcioAndRekorData, Verifier};
-use serde::Serialize;
-use sha2::{Digest, Sha256};
-use tracing::error;
+use std::collections::HashMap;
 
 pub(crate) struct Client {
     verifier: Verifier,
@@ -26,64 +22,23 @@ impl Client {
         })
     }
 
-    pub async fn is_trusted(&mut self, config: &IsTrustedSettings) -> Result<bool> {
-        if !config.has_constraints() {
-            return Err(anyhow!("Must provide value for at least all_of or any_of"));
+    pub async fn is_pub_key_trusted(
+        &mut self,
+        image: String,
+        pub_keys: Vec<String>,
+        annotations: HashMap<String, String>,
+    ) -> Result<bool> {
+        if pub_keys.is_empty() {
+            return Err(anyhow!("Must provide at least one pub key"));
         }
         let result = self
             .verifier
-            .verify(
-                config.image.as_str(),
-                self.docker_config.as_ref(),
-                &config.config,
-            )
+            .verify_pub_key(self.docker_config.as_ref(), image, pub_keys, annotations)
             .await;
 
         match result {
             Ok(_) => Ok(true),
             Err(e) => Err(e),
         }
-    }
-}
-
-#[derive(Serialize, Debug)]
-pub(crate) struct IsTrustedSettings {
-    image: String,
-    config: LatestVerificationConfig,
-}
-
-impl IsTrustedSettings {
-    pub fn new(image: String, config: LatestVerificationConfig) -> Self {
-        IsTrustedSettings { image, config }
-    }
-
-    pub fn has_constraints(&self) -> bool {
-        self.config.all_of.is_some() || self.config.any_of.is_some()
-    }
-
-    // This function returns a hash of the IsTrustedSettings struct.
-    // The has is computed by doing a canonical JSON representation of
-    // the struct.
-    //
-    // This method cannot error, because its value is used by the `cached`
-    // macro, which doesn't allow error handling.
-    // Because of that the method will return the '0' value when something goes
-    // wrong during the serialization operation. This is very unlikely to happen
-    pub fn hash(&self) -> String {
-        let mut buf = Vec::new();
-        let mut ser = serde_json::Serializer::with_formatter(&mut buf, CanonicalFormatter::new());
-        if let Err(e) = self.serialize(&mut ser) {
-            error!(err=?e, settings=?self, "Cannot perform canonical serialization");
-            return "0".to_string();
-        }
-
-        let mut hasher = Sha256::new();
-        hasher.update(&buf);
-        let result = hasher.finalize();
-        result
-            .iter()
-            .map(|v| format!("{:x}", v))
-            .collect::<Vec<String>>()
-            .join("")
     }
 }

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -1,66 +1,64 @@
 use anyhow::{anyhow, Result};
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::Config as SDKVerificationConfig;
 use olpc_cjson::CanonicalFormatter;
+use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::LatestVerificationConfig;
+use policy_fetcher::registry::config::DockerConfig;
 use policy_fetcher::sources::Sources;
-use policy_fetcher::verify::config::{AnyOf, Signature, VerificationConfigV1};
 use policy_fetcher::verify::{FulcioAndRekorData, Verifier};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
-use std::convert::TryFrom;
 use tracing::error;
 
 pub(crate) struct Client {
     verifier: Verifier,
+    docker_config: Option<DockerConfig>,
 }
 
 impl Client {
     pub fn new(
         sources: Option<Sources>,
+        docker_config: Option<DockerConfig>,
         fulcio_and_rekor_data: &FulcioAndRekorData,
     ) -> Result<Self> {
         let verifier = Verifier::new(sources, fulcio_and_rekor_data)?;
-        Ok(Client { verifier })
+        Ok(Client {
+            verifier,
+            docker_config,
+        })
     }
 
-    pub fn is_trusted(&self, config: &SDKVerificationConfig) -> Result<bool> {
-        if !settings.has_constraints() {
+    pub async fn is_trusted(&mut self, config: &IsTrustedSettings) -> Result<bool> {
+        if !config.has_constraints() {
             return Err(anyhow!("Must provide value for at least all_of or any_of"));
         }
-        Err(anyhow::anyhow!("boom"))
-    }
-}
+        let result = self
+            .verifier
+            .verify(
+                config.image.as_str(),
+                self.docker_config.as_ref(),
+                &config.config,
+            )
+            .await;
 
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification as sdk_verification;
-
-fn convertSDKVerificationConfig(sdk_config: sdk_verification::Config) -> Result<VerificationConfigV1> {
-    match sdk_config {
-        sdk_verification::Config::Versioned(versioned_config) => {
-            match versioned_config {
-                sdk_verification::VersionedConfig::V1(v1_config) {
-                    Ok(VerificationConfigV1{
-                        all_of: v1_config.all_of,
-                        any_of: v1_config.any_of,
-                    })
-                },
-                sdk_verification::VersionedConfig::Invalid() => Err(anyhow!("Cannot conver an invalid SDK versioned config")),
-            }
-        },
-        sdk_verification::Config::Invalid => Err(anyhow!(
-            "Cannot convert an invalid SDK verification config",
-        )),
+        match result {
+            Ok(_) => Ok(true),
+            Err(e) => Err(e),
+        }
     }
 }
 
 #[derive(Serialize, Debug)]
 pub(crate) struct IsTrustedSettings {
     image: String,
-    all_of: Option<Vec<Signature>>,
-    any_of: Option<Signature>,
+    config: LatestVerificationConfig,
 }
 
 impl IsTrustedSettings {
+    pub fn new(image: String, config: LatestVerificationConfig) -> Self {
+        IsTrustedSettings { image, config }
+    }
+
     pub fn has_constraints(&self) -> bool {
-        self.all_of.is_some() || self.any_of.is_some()
+        self.config.all_of.is_some() || self.config.any_of.is_some()
     }
 
     // This function returns a hash of the IsTrustedSettings struct.

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -54,7 +54,7 @@ pub(crate) fn host_callback(
                 }
             },
             "oci" => match operation {
-                "v1/verify/pubkeys" => {
+                "v1/verify" => {
                     let req_type: CallbackRequestType =
                         serde_json::from_slice(payload.to_vec().as_ref())?;
                     let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -54,7 +54,7 @@ pub(crate) fn host_callback(
                 }
             },
             "oci" => match operation {
-                "verify" => {
+                "v1/verify/pubkeys" => {
                     let req_type: CallbackRequestType =
                         serde_json::from_slice(payload.to_vec().as_ref())?;
                     let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -17,6 +17,7 @@ use policy_fetcher::kubewarden_policy_sdk::host_capabilities::CallbackRequestTyp
 use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;
 use policy_fetcher::kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
 use policy_fetcher::kubewarden_policy_sdk::settings::SettingsValidationResponse;
+use tokio::sync::oneshot::Receiver;
 
 lazy_static! {
     pub(crate) static ref WAPC_POLICY_MAPPING: RwLock<HashMap<u64, Policy>> =
@@ -54,38 +55,19 @@ pub(crate) fn host_callback(
             },
             "oci" => match operation {
                 "verify" => {
-                    todo!()
-                }
-                "manifest_digest" => {
-                    let policy_mapping = WAPC_POLICY_MAPPING.read().unwrap();
-                    let policy = policy_mapping.get(&policy_id).unwrap();
-
-                    let cb_channel: mpsc::Sender<CallbackRequest> =
-                        if let Some(c) = policy.callback_channel.clone() {
-                            Ok(c)
-                        } else {
-                            error!(
-                                policy_id,
-                                binding,
-                                operation,
-                                "Cannot process waPC request: callback channel not provided"
-                            );
-                            Err(anyhow!(
-                                "Cannot process waPC request: callback channel not provided"
-                            ))
-                        }?;
-
-                    let image = String::from_utf8(payload.to_vec())
-                        .map_err(|_| "Cannot parse given payload as string")?;
-
-                    let (tx, mut rx) = oneshot::channel::<Result<CallbackResponse>>();
+                    let req_type: CallbackRequestType =
+                        serde_json::from_slice(payload.to_vec().as_ref())?;
+                    let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();
                     let req = CallbackRequest {
-                        request: CallbackRequestType::OciManifestDigest {
-                            image: image.clone(),
-                        },
+                        request: req_type,
                         response_channel: tx,
                     };
 
+                    send_request_and_wait_for_response(policy_id, binding, operation, req, rx)
+                }
+                "manifest_digest" => {
+                    let image = String::from_utf8(payload.to_vec())
+                        .map_err(|_| "Cannot parse given payload as string")?;
                     debug!(
                         policy_id,
                         binding,
@@ -93,48 +75,12 @@ pub(crate) fn host_callback(
                         image = image.as_str(),
                         "Sending request via callback channel"
                     );
-                    let send_result = cb_channel.try_send(req);
-                    if let Err(e) = send_result {
-                        return Err(format!(
-                            "Error sending request over callback channel: {:?}",
-                            e
-                        )
-                        .into());
-                    }
-
-                    // wait for the response
-                    loop {
-                        match rx.try_recv() {
-                            Ok(msg) => {
-                                return match msg {
-                                    Ok(resp) => Ok(resp.payload),
-                                    Err(e) => {
-                                        error!(
-                                            policy_id,
-                                            binding,
-                                            operation,
-                                            error = e.to_string().as_str(),
-                                            "callback evaluation failed"
-                                        );
-                                        Err(format!("Callback evaluation failure: {:?}", e).into())
-                                    }
-                                }
-                            }
-                            Err(oneshot::error::TryRecvError::Empty) => {
-                                //  do nothing, keep waiting for a reply
-                            }
-                            Err(e) => {
-                                error!(
-                                    policy_id,
-                                    binding,
-                                    operation,
-                                    error = e.to_string().as_str(),
-                                    "Cannot process waPC request: error obtaining response over callback channel"
-                                );
-                                return Err("Error obtaining response over callback channel".into());
-                            }
-                        }
-                    }
+                    let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();
+                    let req = CallbackRequest {
+                        request: CallbackRequestType::OciManifestDigest { image },
+                        response_channel: tx,
+                    };
+                    send_request_and_wait_for_response(policy_id, binding, operation, req, rx)
                 }
                 _ => {
                     error!("unknown operation: {}", operation);
@@ -161,6 +107,69 @@ pub(crate) fn host_callback(
         _ => {
             error!("unknown binding: {}", binding);
             Err(format!("unknown binding: {}", binding).into())
+        }
+    }
+}
+
+fn send_request_and_wait_for_response(
+    policy_id: u64,
+    binding: &str,
+    operation: &str,
+    req: CallbackRequest,
+    mut rx: Receiver<Result<CallbackResponse>>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    let policy_mapping = WAPC_POLICY_MAPPING.read().unwrap();
+    let policy = policy_mapping.get(&policy_id).unwrap();
+
+    let cb_channel: mpsc::Sender<CallbackRequest> = if let Some(c) = policy.callback_channel.clone()
+    {
+        Ok(c)
+    } else {
+        error!(
+            policy_id,
+            binding, operation, "Cannot process waPC request: callback channel not provided"
+        );
+        Err(anyhow!(
+            "Cannot process waPC request: callback channel not provided"
+        ))
+    }?;
+
+    let send_result = cb_channel.try_send(req);
+    if let Err(e) = send_result {
+        return Err(format!("Error sending request over callback channel: {:?}", e).into());
+    }
+
+    // wait for the response
+    loop {
+        match rx.try_recv() {
+            Ok(msg) => {
+                return match msg {
+                    Ok(resp) => Ok(resp.payload),
+                    Err(e) => {
+                        error!(
+                            policy_id,
+                            binding,
+                            operation,
+                            error = e.to_string().as_str(),
+                            "callback evaluation failed"
+                        );
+                        Err(format!("Callback evaluation failure: {:?}", e).into())
+                    }
+                }
+            }
+            Err(oneshot::error::TryRecvError::Empty) => {
+                //  do nothing, keep waiting for a reply
+            }
+            Err(e) => {
+                error!(
+                    policy_id,
+                    binding,
+                    operation,
+                    error = e.to_string().as_str(),
+                    "Cannot process waPC request: error obtaining response over callback channel"
+                );
+                return Err("Error obtaining response over callback channel".into());
+            }
         }
     }
 }


### PR DESCRIPTION
Fix https://github.com/kubewarden/policy-server/issues/99

- Add Sigstore client to `CallbackHandler`
- New `CallbackRequestType` `SigstoreVerify`, which will be called by a policy and it is used to verify images using Sigstore.