### PR TITLE
Bump v0.2.18 version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.2.17"
+version = "0.2.18"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"


### PR DESCRIPTION
Bumps the policy-evaluator to version v0.2.18. This version updates the kube crate.