### PR TITLE
feat: Allow policy authors to write policies that perform image verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ json-patch = "0.2.6"
 kube = { version = "0.71.0", default-features = false, features = ["client", "rustls-tls"] }
 kubewarden-policy-sdk = "0.3.2"
 lazy_static = "1.4.0"
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.6.1" }
+policy-fetcher = { path ="../policy-fetcher" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.2.18"
+version = "0.3.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"
@@ -24,7 +24,7 @@ json-patch = "0.2.6"
 kube = { version = "0.71.0", default-features = false, features = ["client", "rustls-tls"] }
 kubewarden-policy-sdk = "0.3.2"
 lazy_static = "1.4.0"
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", branch = "sigstore_container_verification" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.0" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ json-patch = "0.2.6"
 kube = { version = "0.71.0", default-features = false, features = ["client", "rustls-tls"] }
 kubewarden-policy-sdk = "0.3.2"
 lazy_static = "1.4.0"
-policy-fetcher = { path ="../policy-fetcher" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", branch = "sigstore_container_verification" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }
@@ -38,7 +38,6 @@ wasmparser = "0.84.0"
 # version of `wapc` has been pushed to crates.io.
 wapc = { git = "https://github.com/wapc/wapc-rs", tag = "wapc@1.0.0-alpha.1" }
 wasmtime-provider = { git = "https://github.com/wapc/wapc-rs", tag = "wapc@1.0.0-alpha.1" }
-url = "2.2.2"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ wasmparser = "0.84.0"
 # version of `wapc` has been pushed to crates.io.
 wapc = { git = "https://github.com/wapc/wapc-rs", tag = "wapc@1.0.0-alpha.1" }
 wasmtime-provider = { git = "https://github.com/wapc/wapc-rs", tag = "wapc@1.0.0-alpha.1" }
+url = "2.2.2"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -4,7 +4,9 @@ use policy_fetcher::{registry::config::DockerConfig, sources::Sources};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
-use crate::callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse};
+use crate::callback_requests::{CallbackRequest, CallbackResponse};
+
+use policy_fetcher::kubewarden_policy_sdk::host_capabilities::CallbackRequestType;
 
 mod oci;
 mod sigstore;
@@ -80,6 +82,7 @@ impl CallbackHandlerBuilder {
 /// code in order to be fulfilled.
 pub struct CallbackHandler {
     oci_client: oci::Client,
+    //sigstore_client: sigstore.Client,
     rx: mpsc::Receiver<CallbackRequest>,
     tx: mpsc::Sender<CallbackRequest>,
     shutdown_channel: oneshot::Receiver<()>,
@@ -134,8 +137,7 @@ impl CallbackHandler {
                             },
                             CallbackRequestType::SigstoreVerify{
                                 image: _,
-                                all_of: _,
-                                any_of: _,
+                                config: _,
                             } => todo!(),
                         }
                     }

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -245,7 +245,7 @@ async fn get_sigstore_pub_key_verification_cached(
     annotations: Option<HashMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
     client
-        .is_pub_key_trusted(image, pub_keys, annotations)
+        .verify_public_key(image, pub_keys, annotations)
         .await
         .map(cached::Return::new)
 }
@@ -272,7 +272,7 @@ async fn get_sigstore_keyless_verification_cached(
     annotations: Option<HashMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
     client
-        .is_keyless_trusted(image, keyless, annotations)
+        .verify_keyless(image, keyless, annotations)
         .await
         .map(cached::Return::new)
 }

--- a/src/callback_handler/sigstore.rs
+++ b/src/callback_handler/sigstore.rs
@@ -1,0 +1,69 @@
+use anyhow::{anyhow, Result};
+use olpc_cjson::CanonicalFormatter;
+use policy_fetcher::sources::Sources;
+use policy_fetcher::verify::config::{AnyOf, Signature};
+use policy_fetcher::verify::Verifier;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tracing::error;
+
+pub(crate) struct Client {
+    verifier: Verifier,
+}
+
+impl Client {
+    pub fn new(
+        sources: Option<Sources>,
+        fulcio_cert: &[u8],
+        rekor_public_key: &str,
+    ) -> Result<Self> {
+        let verifier = Verifier::new(sources, fulcio_cert, rekor_public_key)?;
+        Ok(Client { verifier })
+    }
+
+    pub fn is_trusted(&self, settings: &IsTrustedSettings) -> Result<bool> {
+        if !settings.has_constraints() {
+            return Err(anyhow!("Must provide value for at least all_of or any_of"));
+        }
+        Err(anyhow::anyhow!("boom"))
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub(crate) struct IsTrustedSettings {
+    image: String,
+    all_of: Option<Vec<Signature>>,
+    any_of: Option<Signature>,
+}
+
+impl IsTrustedSettings {
+    pub fn has_constraints(&self) -> bool {
+        self.all_of.is_some() || self.any_of.is_some()
+    }
+
+    // This function returns a hash of the IsTrustedSettings struct.
+    // The has is computed by doing a canonical JSON representation of
+    // the struct.
+    //
+    // This method cannot error, because its value is used by the `cached`
+    // macro, which doesn't allow error handling.
+    // Because of that the method will return the '0' value when something goes
+    // wrong during the serialization operation. This is very unlikely to happen
+    pub fn hash(&self) -> String {
+        let mut buf = Vec::new();
+        let mut ser = serde_json::Serializer::with_formatter(&mut buf, CanonicalFormatter::new());
+        if let Err(e) = self.serialize(&mut ser) {
+            error!(err=?e, settings=?self, "Cannot perform canonical serialization");
+            return "0".to_string();
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(&buf);
+        let result = hasher.finalize();
+        result
+            .iter()
+            .map(|v| format!("{:x}", v))
+            .collect::<Vec<String>>()
+            .join("")
+    }
+}

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -25,7 +25,7 @@ impl Client {
         })
     }
 
-    pub async fn is_pub_key_trusted(
+    pub async fn verify_public_key(
         &mut self,
         image: String,
         pub_keys: Vec<String>,
@@ -48,7 +48,7 @@ impl Client {
         }
     }
 
-    pub async fn is_keyless_trusted(
+    pub async fn verify_keyless(
         &mut self,
         image: String,
         keyless: Vec<KeylessInfo>,

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -1,12 +1,8 @@
 use anyhow::{anyhow, Result};
-use olpc_cjson::CanonicalFormatter;
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::LatestVerificationConfig;
 use policy_fetcher::registry::config::DockerConfig;
 use policy_fetcher::sources::Sources;
 use policy_fetcher::verify::{FulcioAndRekorData, Verifier};
-use serde::Serialize;
-use sha2::{Digest, Sha256};
-use tracing::error;
+use std::collections::HashMap;
 
 pub(crate) struct Client {
     verifier: Verifier,
@@ -26,64 +22,23 @@ impl Client {
         })
     }
 
-    pub async fn is_trusted(&mut self, config: &IsTrustedSettings) -> Result<bool> {
-        if !config.has_constraints() {
-            return Err(anyhow!("Must provide value for at least all_of or any_of"));
+    pub async fn is_pub_key_trusted(
+        &mut self,
+        image: String,
+        pub_keys: Vec<String>,
+        annotations: HashMap<String, String>,
+    ) -> Result<bool> {
+        if pub_keys.is_empty() {
+            return Err(anyhow!("Must provide at least one pub key"));
         }
         let result = self
             .verifier
-            .verify(
-                config.image.as_str(),
-                self.docker_config.as_ref(),
-                &config.config,
-            )
+            .verify_pub_key(self.docker_config.as_ref(), image, pub_keys, annotations)
             .await;
 
         match result {
             Ok(_) => Ok(true),
             Err(e) => Err(e),
         }
-    }
-}
-
-#[derive(Serialize, Debug)]
-pub(crate) struct IsTrustedSettings {
-    image: String,
-    config: LatestVerificationConfig,
-}
-
-impl IsTrustedSettings {
-    pub fn new(image: String, config: LatestVerificationConfig) -> Self {
-        IsTrustedSettings { image, config }
-    }
-
-    pub fn has_constraints(&self) -> bool {
-        self.config.all_of.is_some() || self.config.any_of.is_some()
-    }
-
-    // This function returns a hash of the IsTrustedSettings struct.
-    // The has is computed by doing a canonical JSON representation of
-    // the struct.
-    //
-    // This method cannot error, because its value is used by the `cached`
-    // macro, which doesn't allow error handling.
-    // Because of that the method will return the '0' value when something goes
-    // wrong during the serialization operation. This is very unlikely to happen
-    pub fn hash(&self) -> String {
-        let mut buf = Vec::new();
-        let mut ser = serde_json::Serializer::with_formatter(&mut buf, CanonicalFormatter::new());
-        if let Err(e) = self.serialize(&mut ser) {
-            error!(err=?e, settings=?self, "Cannot perform canonical serialization");
-            return "0".to_string();
-        }
-
-        let mut hasher = Sha256::new();
-        hasher.update(&buf);
-        let result = hasher.finalize();
-        result
-            .iter()
-            .map(|v| format!("{:x}", v))
-            .collect::<Vec<String>>()
-            .join("")
     }
 }

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, Result};
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::KeylessInfo;
+use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::{
+    KeylessInfo, VerificationResponse,
+};
 use policy_fetcher::registry::config::DockerConfig;
 use policy_fetcher::sources::Sources;
 use policy_fetcher::verify::{FulcioAndRekorData, Verifier};
@@ -28,7 +30,7 @@ impl Client {
         image: String,
         pub_keys: Vec<String>,
         annotations: Option<HashMap<String, String>>,
-    ) -> Result<bool> {
+    ) -> Result<VerificationResponse> {
         if pub_keys.is_empty() {
             return Err(anyhow!("Must provide at least one pub key"));
         }
@@ -38,7 +40,10 @@ impl Client {
             .await;
 
         match result {
-            Ok(_) => Ok(true),
+            Ok(digest) => Ok(VerificationResponse {
+                digest,
+                is_trusted: true,
+            }),
             Err(e) => Err(e),
         }
     }
@@ -48,7 +53,7 @@ impl Client {
         image: String,
         keyless: Vec<KeylessInfo>,
         annotations: Option<HashMap<String, String>>,
-    ) -> Result<bool> {
+    ) -> Result<VerificationResponse> {
         if keyless.is_empty() {
             return Err(anyhow!("Must provide keyless info"));
         }
@@ -58,7 +63,10 @@ impl Client {
             .await;
 
         match result {
-            Ok(_) => Ok(true),
+            Ok(digest) => Ok(VerificationResponse {
+                digest,
+                is_trusted: true,
+            }),
             Err(e) => Err(e),
         }
     }

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -1,66 +1,64 @@
 use anyhow::{anyhow, Result};
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::Config as SDKVerificationConfig;
 use olpc_cjson::CanonicalFormatter;
+use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::LatestVerificationConfig;
+use policy_fetcher::registry::config::DockerConfig;
 use policy_fetcher::sources::Sources;
-use policy_fetcher::verify::config::{AnyOf, Signature, VerificationConfigV1};
 use policy_fetcher::verify::{FulcioAndRekorData, Verifier};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
-use std::convert::TryFrom;
 use tracing::error;
 
 pub(crate) struct Client {
     verifier: Verifier,
+    docker_config: Option<DockerConfig>,
 }
 
 impl Client {
     pub fn new(
         sources: Option<Sources>,
+        docker_config: Option<DockerConfig>,
         fulcio_and_rekor_data: &FulcioAndRekorData,
     ) -> Result<Self> {
         let verifier = Verifier::new(sources, fulcio_and_rekor_data)?;
-        Ok(Client { verifier })
+        Ok(Client {
+            verifier,
+            docker_config,
+        })
     }
 
-    pub fn is_trusted(&self, config: &SDKVerificationConfig) -> Result<bool> {
-        if !settings.has_constraints() {
+    pub async fn is_trusted(&mut self, config: &IsTrustedSettings) -> Result<bool> {
+        if !config.has_constraints() {
             return Err(anyhow!("Must provide value for at least all_of or any_of"));
         }
-        Err(anyhow::anyhow!("boom"))
-    }
-}
+        let result = self
+            .verifier
+            .verify(
+                config.image.as_str(),
+                self.docker_config.as_ref(),
+                &config.config,
+            )
+            .await;
 
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification as sdk_verification;
-
-fn convertSDKVerificationConfig(sdk_config: sdk_verification::Config) -> Result<VerificationConfigV1> {
-    match sdk_config {
-        sdk_verification::Config::Versioned(versioned_config) => {
-            match versioned_config {
-                sdk_verification::VersionedConfig::V1(v1_config) {
-                    Ok(VerificationConfigV1{
-                        all_of: v1_config.all_of,
-                        any_of: v1_config.any_of,
-                    })
-                },
-                sdk_verification::VersionedConfig::Invalid() => Err(anyhow!("Cannot conver an invalid SDK versioned config")),
-            }
-        },
-        sdk_verification::Config::Invalid => Err(anyhow!(
-            "Cannot convert an invalid SDK verification config",
-        )),
+        match result {
+            Ok(_) => Ok(true),
+            Err(e) => Err(e),
+        }
     }
 }
 
 #[derive(Serialize, Debug)]
 pub(crate) struct IsTrustedSettings {
     image: String,
-    all_of: Option<Vec<Signature>>,
-    any_of: Option<Signature>,
+    config: LatestVerificationConfig,
 }
 
 impl IsTrustedSettings {
+    pub fn new(image: String, config: LatestVerificationConfig) -> Self {
+        IsTrustedSettings { image, config }
+    }
+
     pub fn has_constraints(&self) -> bool {
-        self.all_of.is_some() || self.any_of.is_some()
+        self.config.all_of.is_some() || self.config.any_of.is_some()
     }
 
     // This function returns a hash of the IsTrustedSettings struct.

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use policy_fetcher::verify::config::{AnyOf, Signature};
+use policy_fetcher::kubewarden_policy_sdk::host_capabilities::CallbackRequestType;
 use tokio::sync::oneshot;
 
 /// Holds the response to a waPC evaluation request
@@ -7,29 +7,6 @@ use tokio::sync::oneshot;
 pub struct CallbackResponse {
     /// The data to be given back to the waPC guest
     pub payload: Vec<u8>,
-}
-
-/// Describes the different kinds of request a waPC guest can make to
-/// our host.
-#[derive(Debug)]
-pub enum CallbackRequestType {
-    /// Require the computation of the manifest digest of an OCI object (be
-    /// it an image or anything else that can be stored into an OCI registry)
-    OciManifestDigest {
-        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
-        image: String,
-    },
-    /// Require the verification of the manifest digest of an OCI object (be
-    /// it an image or anything else that can be stored into an OCI registry)
-    /// to be signed by Sigstore
-    SigstoreVerify {
-        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
-        image: String,
-        /// All these signatures must be present
-        all_of: Option<Vec<Signature>>,
-        /// A user-defined number of these signatures must be present
-        any_of: Option<AnyOf>,
-    },
 }
 
 /// A request sent by some synchronous code (usually waPC's host_callback)

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use policy_fetcher::verify::config::{AnyOf, Signature};
 use tokio::sync::oneshot;
 
 /// Holds the response to a waPC evaluation request
@@ -17,6 +18,17 @@ pub enum CallbackRequestType {
     OciManifestDigest {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
+    },
+    /// Require the verification of the manifest digest of an OCI object (be
+    /// it an image or anything else that can be stored into an OCI registry)
+    /// to be signed by Sigstore
+    SigstoreVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// All these signatures must be present
+        all_of: Option<Vec<Signature>>,
+        /// A user-defined number of these signatures must be present
+        any_of: Option<AnyOf>,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,5 +24,5 @@ pub mod validation_response;
 // consumers of these libraries along with the `policy-evaluator`, so
 // they can access these crates through the `policy-evaluator` itself,
 // streamlining their dependencies as well.
-pub use kubewarden_policy_sdk::metadata::ProtocolVersion;
 pub use policy_fetcher;
+pub use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;

--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -10,8 +10,8 @@ use tokio::sync::mpsc;
 use wapc::WapcHost;
 use wasmtime_provider::WasmtimeEngineProvider;
 
-use kubewarden_policy_sdk::metadata::ProtocolVersion;
-use kubewarden_policy_sdk::settings::SettingsValidationResponse;
+use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;
+use policy_fetcher::kubewarden_policy_sdk::settings::SettingsValidationResponse;
 
 use crate::callback_requests::CallbackRequest;
 use crate::policy::Policy;

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use kubewarden_policy_sdk::metadata::ProtocolVersion;
+use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;

--- a/src/runtimes/burrego.rs
+++ b/src/runtimes/burrego.rs
@@ -8,7 +8,7 @@ use crate::policy_evaluator::{PolicySettings, ValidateRequest};
 use crate::validation_response::{ValidationResponse, ValidationResponseStatus};
 use burrego::opa::host_callbacks::HostCallbacks;
 
-use kubewarden_policy_sdk::settings::SettingsValidationResponse;
+use policy_fetcher::kubewarden_policy_sdk::settings::SettingsValidationResponse;
 
 use crate::policy_evaluator::RegoPolicyExecutionMode;
 use serde::Deserialize;

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -54,7 +54,7 @@ pub(crate) fn host_callback(
                 }
             },
             "oci" => match operation {
-                "v1/verify/pubkeys" => {
+                "v1/verify" => {
                     let req_type: CallbackRequestType =
                         serde_json::from_slice(payload.to_vec().as_ref())?;
                     let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -54,7 +54,7 @@ pub(crate) fn host_callback(
                 }
             },
             "oci" => match operation {
-                "verify" => {
+                "v1/verify/pubkeys" => {
                     let req_type: CallbackRequestType =
                         serde_json::from_slice(payload.to_vec().as_ref())?;
                     let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -17,6 +17,7 @@ use policy_fetcher::kubewarden_policy_sdk::host_capabilities::CallbackRequestTyp
 use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;
 use policy_fetcher::kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
 use policy_fetcher::kubewarden_policy_sdk::settings::SettingsValidationResponse;
+use tokio::sync::oneshot::Receiver;
 
 lazy_static! {
     pub(crate) static ref WAPC_POLICY_MAPPING: RwLock<HashMap<u64, Policy>> =
@@ -54,38 +55,19 @@ pub(crate) fn host_callback(
             },
             "oci" => match operation {
                 "verify" => {
-                    todo!()
-                }
-                "manifest_digest" => {
-                    let policy_mapping = WAPC_POLICY_MAPPING.read().unwrap();
-                    let policy = policy_mapping.get(&policy_id).unwrap();
-
-                    let cb_channel: mpsc::Sender<CallbackRequest> =
-                        if let Some(c) = policy.callback_channel.clone() {
-                            Ok(c)
-                        } else {
-                            error!(
-                                policy_id,
-                                binding,
-                                operation,
-                                "Cannot process waPC request: callback channel not provided"
-                            );
-                            Err(anyhow!(
-                                "Cannot process waPC request: callback channel not provided"
-                            ))
-                        }?;
-
-                    let image = String::from_utf8(payload.to_vec())
-                        .map_err(|_| "Cannot parse given payload as string")?;
-
-                    let (tx, mut rx) = oneshot::channel::<Result<CallbackResponse>>();
+                    let req_type: CallbackRequestType =
+                        serde_json::from_slice(payload.to_vec().as_ref())?;
+                    let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();
                     let req = CallbackRequest {
-                        request: CallbackRequestType::OciManifestDigest {
-                            image: image.clone(),
-                        },
+                        request: req_type,
                         response_channel: tx,
                     };
 
+                    send_request_and_wait_for_response(policy_id, binding, operation, req, rx)
+                }
+                "manifest_digest" => {
+                    let image = String::from_utf8(payload.to_vec())
+                        .map_err(|_| "Cannot parse given payload as string")?;
                     debug!(
                         policy_id,
                         binding,
@@ -93,48 +75,12 @@ pub(crate) fn host_callback(
                         image = image.as_str(),
                         "Sending request via callback channel"
                     );
-                    let send_result = cb_channel.try_send(req);
-                    if let Err(e) = send_result {
-                        return Err(format!(
-                            "Error sending request over callback channel: {:?}",
-                            e
-                        )
-                        .into());
-                    }
-
-                    // wait for the response
-                    loop {
-                        match rx.try_recv() {
-                            Ok(msg) => {
-                                return match msg {
-                                    Ok(resp) => Ok(resp.payload),
-                                    Err(e) => {
-                                        error!(
-                                            policy_id,
-                                            binding,
-                                            operation,
-                                            error = e.to_string().as_str(),
-                                            "callback evaluation failed"
-                                        );
-                                        Err(format!("Callback evaluation failure: {:?}", e).into())
-                                    }
-                                }
-                            }
-                            Err(oneshot::error::TryRecvError::Empty) => {
-                                //  do nothing, keep waiting for a reply
-                            }
-                            Err(e) => {
-                                error!(
-                                    policy_id,
-                                    binding,
-                                    operation,
-                                    error = e.to_string().as_str(),
-                                    "Cannot process waPC request: error obtaining response over callback channel"
-                                );
-                                return Err("Error obtaining response over callback channel".into());
-                            }
-                        }
-                    }
+                    let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();
+                    let req = CallbackRequest {
+                        request: CallbackRequestType::OciManifestDigest { image },
+                        response_channel: tx,
+                    };
+                    send_request_and_wait_for_response(policy_id, binding, operation, req, rx)
                 }
                 _ => {
                     error!("unknown operation: {}", operation);
@@ -161,6 +107,69 @@ pub(crate) fn host_callback(
         _ => {
             error!("unknown binding: {}", binding);
             Err(format!("unknown binding: {}", binding).into())
+        }
+    }
+}
+
+fn send_request_and_wait_for_response(
+    policy_id: u64,
+    binding: &str,
+    operation: &str,
+    req: CallbackRequest,
+    mut rx: Receiver<Result<CallbackResponse>>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    let policy_mapping = WAPC_POLICY_MAPPING.read().unwrap();
+    let policy = policy_mapping.get(&policy_id).unwrap();
+
+    let cb_channel: mpsc::Sender<CallbackRequest> = if let Some(c) = policy.callback_channel.clone()
+    {
+        Ok(c)
+    } else {
+        error!(
+            policy_id,
+            binding, operation, "Cannot process waPC request: callback channel not provided"
+        );
+        Err(anyhow!(
+            "Cannot process waPC request: callback channel not provided"
+        ))
+    }?;
+
+    let send_result = cb_channel.try_send(req);
+    if let Err(e) = send_result {
+        return Err(format!("Error sending request over callback channel: {:?}", e).into());
+    }
+
+    // wait for the response
+    loop {
+        match rx.try_recv() {
+            Ok(msg) => {
+                return match msg {
+                    Ok(resp) => Ok(resp.payload),
+                    Err(e) => {
+                        error!(
+                            policy_id,
+                            binding,
+                            operation,
+                            error = e.to_string().as_str(),
+                            "callback evaluation failed"
+                        );
+                        Err(format!("Callback evaluation failure: {:?}", e).into())
+                    }
+                }
+            }
+            Err(oneshot::error::TryRecvError::Empty) => {
+                //  do nothing, keep waiting for a reply
+            }
+            Err(e) => {
+                error!(
+                    policy_id,
+                    binding,
+                    operation,
+                    error = e.to_string().as_str(),
+                    "Cannot process waPC request: error obtaining response over callback channel"
+                );
+                return Err("Error obtaining response over callback channel".into());
+            }
         }
     }
 }

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -7,15 +7,16 @@ use tracing::{debug, error};
 
 pub(crate) struct Runtime<'a>(pub(crate) &'a mut wapc::WapcHost);
 
-use crate::callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse};
+use crate::callback_requests::{CallbackRequest, CallbackResponse};
 use crate::cluster_context::ClusterContext;
 use crate::policy::Policy;
 use crate::policy_evaluator::{PolicySettings, ValidateRequest};
 use crate::validation_response::ValidationResponse;
 
-use kubewarden_policy_sdk::metadata::ProtocolVersion;
-use kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
-use kubewarden_policy_sdk::settings::SettingsValidationResponse;
+use policy_fetcher::kubewarden_policy_sdk::host_capabilities::CallbackRequestType;
+use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;
+use policy_fetcher::kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
+use policy_fetcher::kubewarden_policy_sdk::settings::SettingsValidationResponse;
 
 lazy_static! {
     pub(crate) static ref WAPC_POLICY_MAPPING: RwLock<HashMap<u64, Policy>> =
@@ -52,6 +53,9 @@ pub(crate) fn host_callback(
                 }
             },
             "oci" => match operation {
+                "verify" => {
+                    todo!()
+                }
                 "manifest_digest" => {
                     let policy_mapping = WAPC_POLICY_MAPPING.read().unwrap();
                     let policy = policy_mapping.get(&policy_id).unwrap();

--- a/src/validation_response.rs
+++ b/src/validation_response.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
+use policy_fetcher::kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
` v1/verify` operation added which can be called from the sdk to verify sigstore signatures for a given image. This new operation will receive a CallbackRequestType  which can be SigstorePubKeyVerify and SigstoreKeylessVerify. Verification results are cached for 60 seconds.

Fix https://github.com/kubewarden/policy-server/issues/99