### PR TITLE
Fix policy SDK dependency graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ cached = "0.30.0"
 hyper = { version = "0.14" }
 json-patch = "0.2.6"
 kube = { version = "0.71.0", default-features = false, features = ["client", "rustls-tls"] }
-kubewarden-policy-sdk = "0.3.2"
+kubewarden-policy-sdk = "0.4.0"
 lazy_static = "1.4.0"
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.0" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.2" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -7,10 +7,10 @@ use tracing::{debug, warn};
 
 use crate::callback_requests::{CallbackRequest, CallbackResponse};
 
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::{
-    KeylessInfo, VerificationResponse,
+use kubewarden_policy_sdk::host_capabilities::{
+    verification::{KeylessInfo, VerificationResponse},
+    CallbackRequestType,
 };
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::CallbackRequestType;
 use policy_fetcher::verify::FulcioAndRekorData;
 
 mod oci;

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -1,7 +1,5 @@
 use anyhow::{anyhow, Result};
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::verification::{
-    KeylessInfo, VerificationResponse,
-};
+use kubewarden_policy_sdk::host_capabilities::verification::{KeylessInfo, VerificationResponse};
 use policy_fetcher::registry::config::DockerConfig;
 use policy_fetcher::sources::Sources;
 use policy_fetcher::verify::config::{LatestVerificationConfig, Signature, Subject};

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::CallbackRequestType;
+use kubewarden_policy_sdk::host_capabilities::CallbackRequestType;
 use tokio::sync::oneshot;
 
 /// Holds the response to a waPC evaluation request

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,5 +24,5 @@ pub mod validation_response;
 // consumers of these libraries along with the `policy-evaluator`, so
 // they can access these crates through the `policy-evaluator` itself,
 // streamlining their dependencies as well.
+pub use kubewarden_policy_sdk::metadata::ProtocolVersion;
 pub use policy_fetcher;
-pub use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;

--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -10,8 +10,8 @@ use tokio::sync::mpsc;
 use wapc::WapcHost;
 use wasmtime_provider::WasmtimeEngineProvider;
 
-use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;
-use policy_fetcher::kubewarden_policy_sdk::settings::SettingsValidationResponse;
+use kubewarden_policy_sdk::metadata::ProtocolVersion;
+use kubewarden_policy_sdk::settings::SettingsValidationResponse;
 
 use crate::callback_requests::CallbackRequest;
 use crate::policy::Policy;

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;
+use kubewarden_policy_sdk::metadata::ProtocolVersion;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;

--- a/src/runtimes/burrego.rs
+++ b/src/runtimes/burrego.rs
@@ -8,7 +8,7 @@ use crate::policy_evaluator::{PolicySettings, ValidateRequest};
 use crate::validation_response::{ValidationResponse, ValidationResponseStatus};
 use burrego::opa::host_callbacks::HostCallbacks;
 
-use policy_fetcher::kubewarden_policy_sdk::settings::SettingsValidationResponse;
+use kubewarden_policy_sdk::settings::SettingsValidationResponse;
 
 use crate::policy_evaluator::RegoPolicyExecutionMode;
 use serde::Deserialize;

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -13,10 +13,10 @@ use crate::policy::Policy;
 use crate::policy_evaluator::{PolicySettings, ValidateRequest};
 use crate::validation_response::ValidationResponse;
 
-use policy_fetcher::kubewarden_policy_sdk::host_capabilities::CallbackRequestType;
-use policy_fetcher::kubewarden_policy_sdk::metadata::ProtocolVersion;
-use policy_fetcher::kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
-use policy_fetcher::kubewarden_policy_sdk::settings::SettingsValidationResponse;
+use kubewarden_policy_sdk::host_capabilities::CallbackRequestType;
+use kubewarden_policy_sdk::metadata::ProtocolVersion;
+use kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
+use kubewarden_policy_sdk::settings::SettingsValidationResponse;
 use tokio::sync::oneshot::Receiver;
 
 lazy_static! {

--- a/src/validation_response.rs
+++ b/src/validation_response.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use policy_fetcher::kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
+use kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
Do not consume the policy SDK via policy-fetcher, this is a leftover from one of the old iterations of the Sigstore integration.

Starting from v0.7.1 of policy-fetcher, the policy SDK is no longer re-exposed by policy-fetcher.

The policy SDK belongs to the policy-evaluator.

Depends on https://github.com/kubewarden/policy-fetcher/pull/83
I'll update this PR once the one against policy-fetcher gets merged

