### PR TITLE
add wapc dns lookup callback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ anyhow = "1.0"
 base64 = "0.13.0"
 burrego = { path = "crates/burrego" }
 cached = "0.30.0"
+dns-lookup = "1.0.8"
 hyper = { version = "0.14" }
 json-patch = "0.2.6"
 kube = { version = "0.71.0", default-features = false, features = ["client", "rustls-tls"] }
-kubewarden-policy-sdk = "0.4.2"
+kubewarden-policy-sdk = "0.5.0"
 lazy_static = "1.4.0"
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.3" }
 serde_json = "1.0"

--- a/crates/burrego/src/main.rs
+++ b/crates/burrego/src/main.rs
@@ -137,7 +137,7 @@ fn main() -> Result<()> {
                     process::exit(1);
                 }
 
-                let entrypoint = matches.value_of("entrypoint").or(Some("0")).unwrap();
+                let entrypoint = matches.value_of("entrypoint").unwrap_or("0");
                 let entrypoint_id = match entrypoint.parse() {
                     Ok(id) => id,
                     _ => evaluator.entrypoint_id(&String::from(entrypoint))?,

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -177,7 +177,7 @@ impl CallbackHandler {
                                 if let Err(e) = req.response_channel.send(response) {
                                     warn!("callback handler: cannot send response back: {:?}", e);
                                 }
-                                },
+                            },
                             CallbackRequestType::SigstoreKeylessVerify {
                                 image,
                                 keyless,
@@ -198,7 +198,25 @@ impl CallbackHandler {
                                 if let Err(e) = req.response_channel.send(response) {
                                     warn!("callback handler: cannot send response back: {:?}", e);
                                 }
-                                },
+                            },
+                            CallbackRequestType::DNSLookupHost {
+                                host,
+                            } => {
+                                let response = dns_lookup::lookup_host(&host).map(|ips| {
+                                        let res: Vec<String> = ips
+                                            .iter()
+                                            .map(|ip| ip.to_string())
+                                            .collect();
+                                        CallbackResponse {
+                                            payload: serde_json::to_vec(&res).unwrap()
+                                        }
+                                    }
+                                ).map_err(anyhow::Error::new);
+
+                                if let Err(e) = req.response_channel.send(response) {
+                                    warn!("callback handler: cannot send response back: {:?}", e);
+                                }
+                            },
                         }
                     }
                 },

--- a/src/callback_handler/oci.rs
+++ b/src/callback_handler/oci.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use policy_fetcher::oci_distribution::Reference;
 use policy_fetcher::{registry::config::DockerConfig, registry::Registry, sources::Sources};
 
 /// Helper struct to interact with an OCI registry
@@ -15,9 +16,16 @@ impl Client {
 
     /// Fetch the manifest digest of the OCI resource referenced via `image`
     pub async fn digest(&self, image: &str) -> Result<String> {
-        let image_with_proto = format!("registry://{}", image);
-        self.registry
+        // this is needed to expand names as `busybox` into
+        // fully resolved references like `docker.io/library/busybox`
+        let image_ref: Reference = image.parse()?;
+
+        let image_with_proto = format!("registry://{}", image_ref.whole());
+        let image_digest = self
+            .registry
             .manifest_digest(&image_with_proto, self.sources.as_ref())
-            .await
+            .await?;
+        serde_json::to_string(&image_digest)
+            .map_err(|e| anyhow!("Cannot serialize response to json: {}", e))
     }
 }

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -65,9 +65,8 @@ pub(crate) fn host_callback(
 
                     send_request_and_wait_for_response(policy_id, binding, operation, req, rx)
                 }
-                "manifest_digest" => {
-                    let image = String::from_utf8(payload.to_vec())
-                        .map_err(|_| "Cannot parse given payload as string")?;
+                "v1/manifest_digest" => {
+                    let image: String = serde_json::from_slice(payload.to_vec().as_ref())?;
                     debug!(
                         policy_id,
                         binding,


### PR DESCRIPTION
This PR extents the waPC capabilities offered to our policy authors by introducing a new API that allows reverse DNS lookup.

This fixes https://github.com/kubewarden/policy-server/issues/236

While working on this PR, I also realized the "OCI get manifest invocations" were not encoding and decoding the waPC payload properly.
