### PR TITLE
Update to latest wasmparser release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 validator = { version = "0.14", features = ["derive"] }
-wasmparser = "0.84.0"
+wasmparser = "0.85.0"
 # Given we are using a git repository, we need to point both
 # dependencies to the same tag. Otherwise, traits that are shared by
 # both crates are considered different. This can be removed once a new

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -155,9 +155,9 @@ impl Metadata {
 
     pub fn from_contents(policy: Vec<u8>) -> Result<Option<Metadata>> {
         for payload in Parser::new(0).parse_all(&policy) {
-            if let Payload::CustomSection { name, data, .. } = payload? {
-                if name == crate::constants::KUBEWARDEN_CUSTOM_SECTION_METADATA {
-                    return Ok(Some(serde_json::from_slice(data)?));
+            if let Payload::CustomSection(reader) = payload? {
+                if reader.name() == crate::constants::KUBEWARDEN_CUSTOM_SECTION_METADATA {
+                    return Ok(Some(serde_json::from_slice(reader.data())?));
                 }
             }
         }


### PR DESCRIPTION
The API changed, hence some pieces of our code had to be refactored.

This supersedes https://github.com/kubewarden/policy-evaluator/pull/126
