### PR TITLE
Update dependencies and tag new release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"
@@ -22,10 +22,11 @@ cached = "0.30.0"
 dns-lookup = "1.0.8"
 hyper = { version = "0.14" }
 json-patch = "0.2.6"
-kube = { version = "0.71.0", default-features = false, features = ["client", "rustls-tls"] }
-kubewarden-policy-sdk = "0.5.0"
+kube = { version = "0.73.0", default-features = false, features = ["client", "rustls-tls"] }
+k8s-openapi = { version = "0.15.0", default-features = false }
+kubewarden-policy-sdk = "0.5.1"
 lazy_static = "1.4.0"
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.5" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.6" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }
@@ -33,13 +34,9 @@ tracing = "0.1"
 tracing-futures = "0.2"
 validator = { version = "0.15", features = ["derive"] }
 wasmparser = "0.85.0"
-# Given we are using a git repository, we need to point both
-# dependencies to the same tag. Otherwise, traits that are shared by
-# both crates are considered different. This can be removed once a new
-# version of `wapc` has been pushed to crates.io.
-wapc = { git = "https://github.com/wapc/wapc-rs", tag = "wapc@1.0.0-alpha.1" }
-wasmtime-provider = { git = "https://github.com/wapc/wapc-rs", tag = "wapc@1.0.0-alpha.1" }
+wapc = "1.0.0"
+wasmtime-provider = "1.0.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"
-k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22"] }
+k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_24"] }

--- a/crates/burrego/Cargo.toml
+++ b/crates/burrego/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrego"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2018"
 
@@ -25,7 +25,7 @@ serde_yaml = "0.8.24"
 tracing = "0.1"
 tracing-subscriber = { version= "0.3", features = ["fmt", "env-filter"] }
 url = "2.2.2"
-wasmtime = "0.33.0"
+wasmtime = "0.34.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 pub extern crate burrego;
-extern crate kube;
 extern crate wasmparser;
 
 pub mod callback_handler;
@@ -24,5 +23,6 @@ pub mod validation_response;
 // consumers of these libraries along with the `policy-evaluator`, so
 // they can access these crates through the `policy-evaluator` itself,
 // streamlining their dependencies as well.
+pub use kube;
 pub use kubewarden_policy_sdk::metadata::ProtocolVersion;
 pub use policy_fetcher;


### PR DESCRIPTION
Release policy-evaluator v0.3.5

Update a bunch of dependencies to a more recent version:

* wapc: consume the v1.0.0 release from crates.io, instead of using a v1.0.0 alpha release from Git
* update to latest version of k8s-openapi
* update the kube dependency
* update to latest version of the kubewarden rust SDK

Also, expose the kube dependency. This allows us to drop the kube dependency on `kwctl` and `policy-server`, which simplifies the upgrade process.

**Note:** the CI will fail until we tag a new release of the Kubewarden Rust SDK (see https://github.com/kubewarden/policy-sdk-rust/pull/42)

This also supersedes these PR:
  * https://github.com/kubewarden/policy-evaluator/pull/130
  * https://github.com/kubewarden/policy-evaluator/pull/129
  * https://github.com/kubewarden/policy-evaluator/pull/99
  * https://github.com/kubewarden/policy-evaluator/pull/95
