### PR TITLE
Allow usage of Wasmtime cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.3.6"
+version = "0.3.7"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"
@@ -35,6 +35,7 @@ tracing-futures = "0.2"
 validator = { version = "0.15", features = ["derive"] }
 wasmparser = "0.85.0"
 wapc = "1.0.0"
+wasmtime = "0.34.0"
 wasmtime-provider = "1.0.0"
 
 [dev-dependencies]

--- a/src/policy_evaluator_builder.rs
+++ b/src/policy_evaluator_builder.rs
@@ -14,6 +14,7 @@ pub struct PolicyEvaluatorBuilder {
     execution_mode: Option<PolicyExecutionMode>,
     settings: Option<serde_json::Map<String, serde_json::Value>>,
     callback_channel: Option<Sender<CallbackRequest>>,
+    wasmtime_cache: bool,
 }
 
 impl PolicyEvaluatorBuilder {
@@ -47,6 +48,12 @@ impl PolicyEvaluatorBuilder {
     /// Sets the policy execution mode
     pub fn execution_mode(mut self, mode: PolicyExecutionMode) -> PolicyEvaluatorBuilder {
         self.execution_mode = Some(mode);
+        self
+    }
+
+    /// Enable Wasmtime cache feature
+    pub fn enable_wasmtime_cache(mut self) -> PolicyEvaluatorBuilder {
+        self.wasmtime_cache = true;
         self
     }
 
@@ -101,6 +108,7 @@ impl PolicyEvaluatorBuilder {
             mode,
             self.settings,
             self.callback_channel,
+            self.wasmtime_cache,
         )
     }
 }


### PR DESCRIPTION
Allow usage of Wasmtime cache feature. This reduces significantly the load time of a policy once the cache has been warmed up.

By default this feature is disable, leading the old behaviour unchanged.

I've will tag a new patch release of policy-evaluator once this PR is merged.
