### PR TITLE
use admission response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.3.7"
+version = "0.4.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"
@@ -24,7 +24,7 @@ hyper = { version = "0.14" }
 json-patch = "0.2.6"
 kube = { version = "0.73.1", default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.15.0", default-features = false }
-kubewarden-policy-sdk = "0.5.1"
+kubewarden-policy-sdk = "0.6.0"
 lazy_static = "1.4.0"
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.7" }
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub extern crate burrego;
 extern crate wasmparser;
 
+pub mod admission_response;
 pub mod callback_handler;
 pub mod callback_requests;
 pub mod cluster_context;
@@ -11,7 +12,6 @@ pub mod policy_evaluator_builder;
 pub mod policy_metadata;
 mod policy_tracing;
 pub mod runtimes;
-pub mod validation_response;
 
 // API's that expose other crate types (such as Kubewarden Policy SDK
 // or `policy_fetcher`) can either implement their own exposed types,

--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -13,13 +13,13 @@ use wasmtime_provider::WasmtimeEngineProvider;
 use kubewarden_policy_sdk::metadata::ProtocolVersion;
 use kubewarden_policy_sdk::settings::SettingsValidationResponse;
 
+use crate::admission_response::AdmissionResponse;
 use crate::callback_requests::CallbackRequest;
 use crate::policy::Policy;
 use crate::runtimes::burrego::Runtime as BurregoRuntime;
 use crate::runtimes::{
     wapc::host_callback as wapc_callback, wapc::Runtime as WapcRuntime, wapc::WAPC_POLICY_MAPPING,
 };
-use crate::validation_response::ValidationResponse;
 
 #[derive(Copy, Clone, PartialEq, serde::Deserialize, serde::Serialize, Debug)]
 pub enum PolicyExecutionMode {
@@ -199,7 +199,7 @@ impl PolicyEvaluator {
     }
 
     #[tracing::instrument(skip(request))]
-    pub fn validate(&mut self, request: ValidateRequest) -> ValidationResponse {
+    pub fn validate(&mut self, request: ValidateRequest) -> AdmissionResponse {
         match self.runtime {
             Runtime::Wapc(ref mut wapc_host) => {
                 WapcRuntime(wapc_host).validate(&self.settings, &request)


### PR DESCRIPTION
Rename the `ValidationResponse` object to be `AdmissionResponse`. This uses the same terminology of Kubernetes. This is needed later on, inside of policy-server, when building proper AdmissionResponse `Response` objects.

While using the `AdmissionResponse`, make use of the fields that have been just exposed by the Rust policy SDK. This ensures we can create any kind of AdmissionResponse that Kubernetes supports.
