### PR TITLE
handle delete operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ base64 = "0.13.0"
 burrego = { path = "crates/burrego" }
 cached = "0.34.1"
 dns-lookup = "1.0.8"
-hyper = { version = "0.14" }
 json-patch = "0.2.6"
 kube = { version = "0.73.1", default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.15.0", default-features = false }

--- a/src/admission_response.rs
+++ b/src/admission_response.rs
@@ -63,11 +63,7 @@ impl AdmissionResponse {
     }
 
     pub fn reject_internal_server_error(uid: String, message: String) -> AdmissionResponse {
-        AdmissionResponse::reject(
-            uid,
-            format!("internal server error: {}", message),
-            hyper::StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
-        )
+        AdmissionResponse::reject(uid, format!("internal server error: {}", message), 500)
     }
 
     pub fn from_policy_validation_response(

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -203,16 +203,8 @@ impl<'a> Runtime<'a> {
     ) -> AdmissionResponse {
         let uid = request.uid();
 
-        let req_obj = match request.0.get("object") {
-            Some(req_obj) => req_obj,
-            None => {
-                return AdmissionResponse::reject(
-                    uid.to_string(),
-                    "request doesn't have an 'object' value".to_string(),
-                    hyper::StatusCode::BAD_REQUEST.as_u16(),
-                );
-            }
-        };
+        //NOTE: object is null for DELETE operations
+        let req_obj = request.0.get("object");
 
         let validate_params = json!({
             "request": request,


### PR DESCRIPTION
Handle DELETE operations

DELETE operations have a null 'object' inside of the 'request'.

This removes the old validation we had in place that actually prevented the creation of policies dealing with DELETE operations.

This code introduces a check to ensure a policy author doesn't attempt a mutation operation when a DELETE happens.


While working on that, I discovered we were requiring the hyper crate. The hyper dependency was used only to access a constant definig the HTTP status of for internal server error.
That was quite an overkill...
