### PR TITLE
Update to latest stable release of wasmtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,7 @@ url = { version = "2.2.2", features = ["serde"] }
 validator = { version = "0.15", features = ["derive"] }
 wasmparser = "0.86.0"
 wapc = "1.0.0"
-wasmtime = "0.34.0"
-wasmtime-provider = "1.0.0"
+wasmtime-provider = "1.0.1"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/crates/burrego/Cargo.toml
+++ b/crates/burrego/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.8.24"
 tracing = "0.1"
 tracing-subscriber = { version= "0.3", features = ["fmt", "env-filter"] }
 url = "2.2.2"
-wasmtime = "0.34.0"
+wasmtime = "0.38.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -8,6 +8,7 @@ use std::{
 use tokio::sync::mpsc;
 
 use wapc::WapcHost;
+use wasmtime_provider::wasmtime;
 use wasmtime_provider::WasmtimeEngineProvider;
 
 use kubewarden_policy_sdk::metadata::ProtocolVersion;


### PR DESCRIPTION
Consume the lastest versions of wasmtime. The waPC provider is now exporting the version of wasmtime it depends against, which simplifies our `Cargo.toml` file.
