### PR TITLE
Consume SDK 0.6.2 for `v2/verify`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ dns-lookup = "1.0.8"
 json-patch = "0.2.6"
 kube = { version = "0.73.1", default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.15.0", default-features = false }
-kubewarden-policy-sdk = "0.6.1"
+kubewarden-policy-sdk = "0.6.2"
 lazy_static = "1.4.0"
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.8" }
 serde_json = "1.0"

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, Result};
-use kubewarden_policy_sdk::host_capabilities::verification::{KeylessInfo, VerificationResponse};
+use kubewarden_policy_sdk::host_capabilities::verification::{
+    KeylessInfo, KeylessPrefixInfo, VerificationResponse,
+};
 use policy_fetcher::registry::config::DockerConfig;
 use policy_fetcher::sources::Sources;
 use policy_fetcher::verify::config::{LatestVerificationConfig, Signature, Subject};
@@ -101,17 +103,17 @@ impl Client {
     pub async fn verify_keyless_prefix(
         &mut self,
         image: String,
-        keyless: Vec<KeylessInfo>,
+        keyless_prefix: Vec<KeylessPrefixInfo>,
         annotations: Option<HashMap<String, String>>,
     ) -> Result<VerificationResponse> {
-        if keyless.is_empty() {
+        if keyless_prefix.is_empty() {
             return Err(anyhow!("Must provide keyless info"));
         }
         // Build interim VerificationConfig:
         //
         let mut signatures_all_of: Vec<Signature> = Vec::new();
-        for k in keyless.iter() {
-            let prefix = url::Url::parse(&k.subject).expect("Cannot build url prefix");
+        for k in keyless_prefix.iter() {
+            let prefix = url::Url::parse(&k.url_prefix).expect("Cannot build url prefix");
             let signature = Signature::GenericIssuer {
                 issuer: k.issuer.clone(),
                 subject: Subject::UrlPrefix(prefix),

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -54,7 +54,7 @@ pub(crate) fn host_callback(
                 }
             },
             "oci" => match operation {
-                "v1/verify" => {
+                "v1/verify" | "v2/verify" => {
                     let req_type: CallbackRequestType =
                         serde_json::from_slice(payload.to_vec().as_ref())?;
                     let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();


### PR DESCRIPTION
## Description

Consume deambiguation of KeylessPrefix request.
Support v2/verify callbacks.
