### PR TITLE
Allow fulcio and rekor data to be None

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"
@@ -25,7 +25,7 @@ kube = { version = "0.74.0", default-features = false, features = ["client", "ru
 k8s-openapi = { version = "0.15.0", default-features = false }
 kubewarden-policy-sdk = "0.6.3"
 lazy_static = "1.4.0"
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.8" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.9" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -53,8 +53,11 @@ impl<'a> CallbackHandlerBuilder<'a> {
         self
     }
 
-    pub fn fulcio_and_rekor_data(mut self, fulcio_and_rekor_data: &'a FulcioAndRekorData) -> Self {
-        self.fulcio_and_rekor_data = Some(fulcio_and_rekor_data);
+    pub fn fulcio_and_rekor_data(
+        mut self,
+        fulcio_and_rekor_data: Option<&'a FulcioAndRekorData>,
+    ) -> Self {
+        self.fulcio_and_rekor_data = fulcio_and_rekor_data;
         self
     }
 
@@ -78,15 +81,12 @@ impl<'a> CallbackHandlerBuilder<'a> {
         let shutdown_channel = self
             .shutdown_channel
             .ok_or_else(|| anyhow!("shutdown_channel_rx not provided"))?;
-        let fulcio_and_rekor_data = self
-            .fulcio_and_rekor_data
-            .ok_or_else(|| anyhow!("fulcio_and_rekor_data not provided"))?;
 
         let oci_client = oci::Client::new(self.oci_sources.clone(), self.docker_config.clone());
         let sigstore_client = sigstore_verification::Client::new(
             self.oci_sources.clone(),
             self.docker_config.clone(),
-            fulcio_and_rekor_data,
+            self.fulcio_and_rekor_data,
         )?;
 
         Ok(CallbackHandler {

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -17,7 +17,7 @@ impl Client {
     pub fn new(
         sources: Option<Sources>,
         docker_config: Option<DockerConfig>,
-        fulcio_and_rekor_data: &FulcioAndRekorData,
+        fulcio_and_rekor_data: Option<&FulcioAndRekorData>,
     ) -> Result<Self> {
         let verifier = Verifier::new(sources, fulcio_and_rekor_data)?;
         Ok(Client {


### PR DESCRIPTION
Do not fail when Fulcio and Rekor data are None. The Sigstore integration will still work, but it will provide some false negatives.

False netative means: a perfectly valid signature produced with keyless mode will be reported as non valid.

This is currently required to handle the case when the upstream TUF repository of Sigstore is broken.
