### PR TITLE
Expose the validator crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,4 @@ pub mod runtimes;
 pub use kube;
 pub use kubewarden_policy_sdk::metadata::ProtocolVersion;
 pub use policy_fetcher;
+pub use validator;


### PR DESCRIPTION
kwctl uses validator too. When the `validator` version between kwctl and policy-evaluator is not the same, there could be compilation errors. This happens when the validator API breaks, like during the 0.15 to 0.16 upgrade.

Currently we would have to bump `validator` inside of `policy_evaluator`, tag a new release and then update both the `validator` and the `policy_evaluator` versions inside of kwctl.

By re-exposing the `validator` crate via the `policy_evaluator` we make the maintenance task easier.
