### PR TITLE
Fix update all patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ url = { version = "2.2.2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 wasmparser = "0.90.0"
 wapc = "1.0.0"
-wasmtime-provider = "1.0.2"
+wasmtime-provider = { version = "1.1.0", features = ["cache"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ url = { version = "2.2.2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 wasmparser = "0.90.0"
 wapc = "1.0.0"
-wasmtime-provider = "1.0.1"
+wasmtime-provider = "1.0.2"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/crates/burrego/Cargo.toml
+++ b/crates/burrego/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.60"
+anyhow = "1.0.63"
 base64 = "0.13.0"
-chrono = "0.4.20"
+chrono = "0.4.22"
 chrono-tz = "0.6.3"
 gtmpl = "0.7.1"
 gtmpl_value = "0.5.1"
@@ -19,8 +19,8 @@ lazy_static = "1.4.0"
 regex = "1.5.6"
 semver = "1.0.13"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.83"
-serde_yaml = "0.9.4"
+serde_json = "1.0.85"
+serde_yaml = "0.9.10"
 tracing = "0.1"
 tracing-subscriber = { version= "0.3", features = ["fmt", "env-filter"] }
 url = "2.2.2"

--- a/crates/burrego/Cargo.toml
+++ b/crates/burrego/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.9.10"
 tracing = "0.1"
 tracing-subscriber = { version= "0.3", features = ["fmt", "env-filter"] }
 url = "2.2.2"
-wasmtime = "0.39.1"
+wasmtime = "0.40"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/crates/burrego/Cargo.toml
+++ b/crates/burrego/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.9.10"
 tracing = "0.1"
 tracing-subscriber = { version= "0.3", features = ["fmt", "env-filter"] }
 url = "2.2.2"
-wasmtime = "0.38.1"
+wasmtime = "0.39.1"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"


### PR DESCRIPTION
Update a bunch of outdated deps. This is built on top of https://github.com/kubewarden/policy-evaluator/pull/173 and fixes the errors reported.

| Package | Type | Update | Change |
|---|---|---|---|
| [anyhow](https://togithub.com/dtolnay/anyhow) | dependencies | patch | `1.0.60` -> `1.0.63` |
| [chrono](https://togithub.com/chronotope/chrono) | dependencies | patch | `0.4.20` -> `0.4.22` |
| [serde_json](https://togithub.com/serde-rs/json) | dependencies | patch | `1.0.83` -> `1.0.85` |
| [serde_yaml](https://togithub.com/dtolnay/serde-yaml) | dependencies | patch | `0.9.4` -> `0.9.10` |
| [wasmtime-provider](https://wapc.io) | dependencies | patch | `1.0.1` -> `1.1.0` |

---

### Release Notes

<details>
<summary>dtolnay/anyhow</summary>

### [`v1.0.63`](https://togithub.com/dtolnay/anyhow/releases/tag/1.0.63)

[Compare Source](https://togithub.com/dtolnay/anyhow/compare/1.0.62...1.0.63)

-   Expose backtraces via the new "generic member access" API on the Error trait ([https://github.com/rust-lang/rust/issues/99301](https://togithub.com/rust-lang/rust/issues/99301), [https://github.com/rust-lang/rust/issues/96024](https://togithub.com/rust-lang/rust/issues/96024))

### [`v1.0.62`](https://togithub.com/dtolnay/anyhow/releases/tag/1.0.62)

[Compare Source](https://togithub.com/dtolnay/anyhow/compare/1.0.61...1.0.62)

-   Fix extra rebuilding when interleaving command-line `cargo` invocations with IDE builds ([#&#8203;261](https://togithub.com/dtolnay/anyhow/issues/261))

### [`v1.0.61`](https://togithub.com/dtolnay/anyhow/releases/tag/1.0.61)

[Compare Source](https://togithub.com/dtolnay/anyhow/compare/1.0.60...1.0.61)

-   Work around rust-analyzer builds poisoning all subsequent command-line cargo builds ([#&#8203;252](https://togithub.com/dtolnay/anyhow/issues/252))

</details>

<details>
<summary>chronotope/chrono</summary>

### [`v0.4.22`](https://togithub.com/chronotope/chrono/releases/tag/v0.4.22)

[Compare Source](https://togithub.com/chronotope/chrono/compare/v0.4.21...v0.4.22)

Unfortunately the introduction of the iana-time-zone dependency in 0.4.21 caused some new regressions with lesser known platforms. This release fixes all of the issues we've encountered, improving the situation on some WebAssembly targets, SGX and on macOS/iOS. We've improved our CI setup to hopefully catch more of these issues before release in the future.

-   Make wasm-bindgen optional on `wasm32-unknown-unknown` target ([#&#8203;771](https://togithub.com/chronotope/chrono/issues/771))
-   Avoid iana-time-zone dependency on `x86_64-fortanix-unknown-sgx` ([#&#8203;767](https://togithub.com/chronotope/chrono/issues/767), thanks to [@&#8203;trevor-crypto](https://togithub.com/trevor-crypto))
-   Update `iana-time-zone` version to 0.1.44 to avoid cyclic dependencies ([#&#8203;773](https://togithub.com/chronotope/chrono/issues/773), thanks to [@&#8203;Kijewski](https://togithub.com/Kijewski) for the upstream PRs)
-   Clarify documentation about year range in formatting/parsing ([#&#8203;765](https://togithub.com/chronotope/chrono/issues/765))

### [`v0.4.21`](https://togithub.com/chronotope/chrono/releases/tag/v0.4.21)

[Compare Source](https://togithub.com/chronotope/chrono/compare/v0.4.20...v0.4.21)

0.4.21 is a bugfix release that mainly fixes one regression from 0.4.20:

-   Fall back to UTC in case no timezone is found. Unfortunately this is a regression from the changes we made in 0.4.20 where we now parse the timezone database ourselves. Before 0.4.20, `TimeZone::now()` fell back to UTC in the case it could not find the current timezone, but the new implementation panicked in that case.
-   Correctly detect timezone on Android (also [#&#8203;756](https://togithub.com/chronotope/chrono/issues/756)). Android does have the timezone database installed, but it's in a different path, and it does not use `/etc/localtime` to keep track of the current timezone. Instead we now use the iana-time-zone crate as a dependency, since it already has quite a bit of logic for finding the current timezone on a host of platforms.

Additionally, there is a documentation fix that reverts an incorrect guarantee:

-   Document that `%Y` can have a negative value, both in formatting and in parsing ([#&#8203;760](https://togithub.com/chronotope/chrono/issues/760), thanks to [@&#8203;alex](https://togithub.com/alex))

</details>

<details>
<summary>serde-rs/json</summary>

### [`v1.0.85`](https://togithub.com/serde-rs/json/releases/tag/v1.0.85)

[Compare Source](https://togithub.com/serde-rs/json/compare/v1.0.84...v1.0.85)

-   Make `Display` for `Number` produce the same representation as serializing ([#&#8203;919](https://togithub.com/serde-rs/json/issues/919))

### [`v1.0.84`](https://togithub.com/serde-rs/json/releases/tag/v1.0.84)

[Compare Source](https://togithub.com/serde-rs/json/compare/v1.0.83...v1.0.84)

-   Make `Debug` impl of `serde_json::Value` more compact ([#&#8203;918](https://togithub.com/serde-rs/json/issues/918))

</details>

<details>
<summary>dtolnay/serde-yaml</summary>

### [`v0.9.10`](https://togithub.com/dtolnay/serde-yaml/releases/tag/0.9.10)

[Compare Source](https://togithub.com/dtolnay/serde-yaml/compare/0.9.9...0.9.10)

-   Make `Display` for `Number` produce the same representation as serializing ([#&#8203;316](https://togithub.com/dtolnay/serde-yaml/issues/316))

### [`v0.9.9`](https://togithub.com/dtolnay/serde-yaml/releases/tag/0.9.9)

[Compare Source](https://togithub.com/dtolnay/serde-yaml/compare/0.9.8...0.9.9)

-   Add [serde_yaml::with::singleton_map_recursive](https://docs.rs/serde_yaml/0.9.9/serde_yaml/with/singleton_map_recursive/index.html)

### [`v0.9.8`](https://togithub.com/dtolnay/serde-yaml/releases/tag/0.9.8)

[Compare Source](https://togithub.com/dtolnay/serde-yaml/compare/0.9.7...0.9.8)

-   Fix serialization of `TaggedValue` when used with `to_value` ([#&#8203;313](https://togithub.com/dtolnay/serde-yaml/issues/313))

### [`v0.9.7`](https://togithub.com/dtolnay/serde-yaml/releases/tag/0.9.7)

[Compare Source](https://togithub.com/dtolnay/serde-yaml/compare/0.9.6...0.9.7)

-   Allow an empty plain scalar to deserialize as an empty map or seq ([#&#8203;304](https://togithub.com/dtolnay/serde-yaml/issues/304))

### [`v0.9.6`](https://togithub.com/dtolnay/serde-yaml/releases/tag/0.9.6)

[Compare Source](https://togithub.com/dtolnay/serde-yaml/compare/0.9.5...0.9.6)

-   Fix tag not getting serialized in certain map values ([#&#8203;302](https://togithub.com/dtolnay/serde-yaml/issues/302))

### [`v0.9.5`](https://togithub.com/dtolnay/serde-yaml/releases/tag/0.9.5)

[Compare Source](https://togithub.com/dtolnay/serde-yaml/compare/0.9.4...0.9.5)

-   Implement `Display` trait for `serde_yaml::value::Tag` ([#&#8203;307](https://togithub.com/dtolnay/serde-yaml/issues/307), thanks [@&#8203;masinc](https://togithub.com/masinc))

</details>