### PR TITLE
feat: implement sigstore cert verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,13 @@ dns-lookup = "1.0.8"
 json-patch = "0.2.6"
 kube = { version = "0.76.0", default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.16.0", default-features = false }
-kubewarden-policy-sdk = "0.8.2"
+kubewarden-policy-sdk = "0.8.3"
+itertools = "0.10"
 lazy_static = "1.4.0"
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.15" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.16" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.10"
 tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-futures = "0.2"

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -47,8 +47,8 @@ pub enum CallbackRequestType {
         annotations: Option<HashMap<String, String>>,
     },
 
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore, using keyless mode
+    /// Require the verification of the manifest digest of an OCI object to be
+    /// signed by Sigstore, using keyless mode
     SigstoreKeylessVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
@@ -58,9 +58,9 @@ pub enum CallbackRequestType {
         annotations: Option<HashMap<String, String>>,
     },
 
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore using keyless mode, where the passed subject is a URL
-    // prefix of the subject to match
+    /// Require the verification of the manifest digest of an OCI object to be
+    /// signed by Sigstore using keyless mode, where the passed subject is a URL
+    /// prefix of the subject to match
     SigstoreKeylessPrefixVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
@@ -70,8 +70,8 @@ pub enum CallbackRequestType {
         annotations: Option<HashMap<String, String>>,
     },
 
-    // Require the verification of the manifest digest of an OCI object to be
-    // signed by Sigstore using keyless mode and performed in GitHub Actions
+    /// Require the verification of the manifest digest of an OCI object to be
+    /// signed by Sigstore using keyless mode and performed in GitHub Actions
     SigstoreGithubActionsVerify {
         /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
         image: String,
@@ -79,6 +79,28 @@ pub enum CallbackRequestType {
         owner: String,
         /// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
         repo: Option<String>,
+        /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+        annotations: Option<HashMap<String, String>>,
+    },
+
+    /// Require the verification of the manifest digest of an OCI object
+    /// using the user provided certificate
+    SigstoreCertificateVerify {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+        /// PEM encoded certificate used to verify the signature
+        certificate: Vec<u8>,
+        /// Optional - the certificate chain that is used to verify the provided
+        /// certificate. When not specified, the certificate is assumed to be trusted
+        certificate_chain: Option<Vec<Vec<u8>>>,
+        /// Require the  signature layer to have a Rekor bundle.
+        /// Having a Rekor bundle allows further checks to be performed,
+        /// like ensuring the signature has been produced during the validity
+        /// time frame of the certificate.
+        ///
+        /// It is recommended to set this value to `true` to have a more secure
+        /// verification process.
+        require_rekor_bundle: bool,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
         annotations: Option<HashMap<String, String>>,
     },
@@ -126,6 +148,19 @@ impl From<SigstoreVerificationInputV2> for CallbackRequestType {
                 image,
                 owner,
                 repo,
+                annotations,
+            },
+            SigstoreVerificationInputV2::SigstoreCertificateVerify {
+                image,
+                certificate,
+                certificate_chain,
+                require_rekor_bundle,
+                annotations,
+            } => CallbackRequestType::SigstoreCertificateVerify {
+                image,
+                certificate,
+                certificate_chain,
+                require_rekor_bundle,
                 annotations,
             },
         }


### PR DESCRIPTION
Allow sigstore based verification to be done using a certificate provided by the user.

This is required to implement: https://github.com/kubewarden/verify-image-signatures/issues/39

**Note:** I'm currently using code from git branches, this is going to be changed as soon as everything gets merged
