### PR TITLE
fix!: Make `verify_certificate()`, return `Result<BoolWithReason>`, & bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ dns-lookup = "1.0.8"
 json-patch = "0.2.6"
 kube = { version = "0.76.0", default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.16.0", default-features = false }
-kubewarden-policy-sdk = "0.8.4"
+kubewarden-policy-sdk = "0.8.5"
 itertools = "0.10"
 lazy_static = "1.4.0"
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.16" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.4.16"
+version = "0.4.17"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/src/callback_handler/crypto.rs
+++ b/src/callback_handler/crypto.rs
@@ -274,6 +274,8 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             cert_chain: Some(cert_chain),
             not_after: None,
         };
+
+        // compiler thinks 'reason' is unused, doesn't detect it's used in 'matches!()'
         let _reason = "Certificate is not trusted by the provided cert chain".to_string();
         assert!(matches!(
             verify_certificate(req),
@@ -342,6 +344,8 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             cert_chain: None,
             not_after: Some(Utc::now().to_rfc3339()),
         };
+
+        // compiler thinks 'reason' is unused, doesn't detect it's used in 'matches!()'
         let _reason = "Certificate is being used after its expiration date".to_string();
         assert!(matches!(
             verify_certificate(req),
@@ -360,6 +364,8 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             cert_chain: None,
             not_after: None,
         };
+
+        // compiler thinks 'reason' is unused, doesn't detect it's used in 'matches!()'
         let _reason = "Certificate is being used before its validity date".to_string();
         assert!(matches!(
             verify_certificate(req),

--- a/src/callback_handler/crypto.rs
+++ b/src/callback_handler/crypto.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, FixedOffset, Utc};
-use kubewarden_policy_sdk::host_capabilities::crypto::{Certificate, CertificateEncoding};
+use kubewarden_policy_sdk::host_capabilities::crypto::{
+    BoolWithReason, Certificate, CertificateEncoding,
+};
 use kubewarden_policy_sdk::host_capabilities::crypto_v1::CertificateVerificationRequest;
 use tracing::debug;
 
@@ -9,13 +11,6 @@ use tracing::debug;
 struct CertificatePool {
     trusted_roots: Vec<picky::x509::Cert>,
     intermediates: Vec<picky::x509::Cert>,
-}
-
-#[derive(Debug)]
-/// Used as return of verify_certificate()
-pub enum BoolWithReason {
-    True,
-    False(String),
 }
 
 /// verify_certificate verifies the validity of the certificate, and if it is
@@ -149,9 +144,11 @@ impl CertificatePool {
 
 #[cfg(test)]
 mod tests {
-    use crate::callback_handler::{verify_certificate, BoolWithReason};
+    use crate::callback_handler::verify_certificate;
     use chrono::Utc;
-    use kubewarden_policy_sdk::host_capabilities::crypto::{Certificate, CertificateEncoding};
+    use kubewarden_policy_sdk::host_capabilities::crypto::{
+        BoolWithReason, Certificate, CertificateEncoding,
+    };
     use kubewarden_policy_sdk::host_capabilities::crypto_v1::CertificateVerificationRequest;
 
     const ROOT_CA1_PEM: &str = "-----BEGIN CERTIFICATE-----

--- a/src/callback_handler/crypto.rs
+++ b/src/callback_handler/crypto.rs
@@ -249,7 +249,7 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             encoding: CertificateEncoding::Pem,
             data: INTERMEDIATE_CA1_PEM.as_bytes().to_vec(),
         };
-        let req: CertificateVerificationRequest = CertificateVerificationRequest {
+        let req = CertificateVerificationRequest {
             cert,
             cert_chain: Some(cert_chain),
             not_after: None,
@@ -269,7 +269,7 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             encoding: CertificateEncoding::Pem,
             data: INTERMEDIATE_CA1_PEM.as_bytes().to_vec(),
         };
-        let req: CertificateVerificationRequest = CertificateVerificationRequest {
+        let req = CertificateVerificationRequest {
             cert,
             cert_chain: Some(cert_chain),
             not_after: None,
@@ -287,7 +287,7 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             encoding: CertificateEncoding::Pem,
             data: INTERMEDIATE_CA1_PEM.as_bytes().to_vec(),
         };
-        let req: CertificateVerificationRequest = CertificateVerificationRequest {
+        let req = CertificateVerificationRequest {
             cert,
             cert_chain: None,
             not_after: None,
@@ -306,7 +306,7 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             encoding: CertificateEncoding::Pem,
             data: INTERMEDIATE_CA2_EXPIRED_PEM.as_bytes().to_vec(),
         };
-        let req: CertificateVerificationRequest = CertificateVerificationRequest {
+        let req = CertificateVerificationRequest {
             cert,
             cert_chain: Some(cert_chain),
             not_after: None, // not checking expiration
@@ -320,7 +320,7 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             encoding: CertificateEncoding::Pem,
             data: INTERMEDIATE_CA2_EXPIRED_PEM.as_bytes().to_vec(),
         };
-        let req: CertificateVerificationRequest = CertificateVerificationRequest {
+        let req = CertificateVerificationRequest {
             cert,
             cert_chain: None,
             not_after: Some("malformed".to_string()),
@@ -337,7 +337,7 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             encoding: CertificateEncoding::Pem,
             data: INTERMEDIATE_CA2_EXPIRED_PEM.as_bytes().to_vec(),
         };
-        let req: CertificateVerificationRequest = CertificateVerificationRequest {
+        let req = CertificateVerificationRequest {
             cert,
             cert_chain: None,
             not_after: Some(Utc::now().to_rfc3339()),
@@ -355,7 +355,7 @@ iDAKBggqhkjOPQQDAgNIADBFAiEArSsdE5dDXqAU2vM3ThT8GvTnjkWhER3l9v1j
             encoding: CertificateEncoding::Pem,
             data: INTERMEDIATE_CA_NOT_BEFORE_PEM.as_bytes().to_vec(),
         };
-        let req: CertificateVerificationRequest = CertificateVerificationRequest {
+        let req = CertificateVerificationRequest {
             cert,
             cert_chain: None,
             not_after: None,

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -19,7 +19,7 @@ mod crypto;
 mod oci;
 mod sigstore_verification;
 
-pub use crypto::{verify_certificate, BoolWithReason};
+pub use crypto::verify_certificate;
 
 const DEFAULT_CHANNEL_BUFF_SIZE: usize = 100;
 

--- a/src/callback_handler/mod.rs
+++ b/src/callback_handler/mod.rs
@@ -19,7 +19,7 @@ mod crypto;
 mod oci;
 mod sigstore_verification;
 
-pub use crypto::verify_certificate;
+pub use crypto::{verify_certificate, BoolWithReason};
 
 const DEFAULT_CHANNEL_BUFF_SIZE: usize = 100;
 

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -8,14 +8,14 @@ use tracing::{debug, error};
 pub(crate) struct Runtime<'a>(pub(crate) &'a mut wapc::WapcHost);
 
 use crate::admission_response::AdmissionResponse;
-use crate::callback_handler::{verify_certificate, BoolWithReason};
+use crate::callback_handler::verify_certificate;
 use crate::callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse};
 use crate::cluster_context::ClusterContext;
 use crate::policy::Policy;
 use crate::policy_evaluator::{PolicySettings, ValidateRequest};
 
 use kubewarden_policy_sdk::host_capabilities::{
-    crypto_v1::CertificateVerificationRequest, crypto_v1::CertificateVerificationResponse,
+    crypto_v1::{CertificateVerificationRequest, CertificateVerificationResponse},
     SigstoreVerificationInputV1, SigstoreVerificationInputV2,
 };
 use kubewarden_policy_sdk::metadata::ProtocolVersion;
@@ -130,16 +130,7 @@ pub(crate) fn host_callback(
                     let req: CertificateVerificationRequest =
                         serde_json::from_slice(payload.to_vec().as_ref())?;
                     let response: CertificateVerificationResponse = match verify_certificate(req) {
-                        Ok(b) => match b {
-                            BoolWithReason::True => CertificateVerificationResponse {
-                                trusted: true,
-                                reason: "".to_string(),
-                            },
-                            BoolWithReason::False(reason) => CertificateVerificationResponse {
-                                trusted: false,
-                                reason,
-                            },
-                        },
+                        Ok(b) => b.into(),
                         Err(e) => {
                             return Err(format!("Error when verifying certificate: {}", e).into())
                         }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/verify-image-signatures/pull/47#discussion_r1034836373

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Make `verify_certificate()`, return `Result<policy-evaluator::BoolWithReason>`. Response either returns:
* `Ok(BoolWithReason::True)`.
* `Ok(BoolWithReason::False((reason))` with ``reason` such as "cert not trusted by cert
  chain", or "cert expired".
* `Err(e)`, with `e` such as "cert not in PEM format", or "not_after
  datetime not in RFC 3339 format".

Bump version to 0.4.17

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Unit tests amended.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
