### PR TITLE
fix repo policies and timeout protection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.6.1"
+version = "0.6.2"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/crates/burrego/Cargo.toml
+++ b/crates/burrego/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrego"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2021"
 


### PR DESCRIPTION
The Wasmtime Linker failed the initialization of Rego-based policies when the timeout protection (epoch deadline) feature was turned on.

This happens because Rego policies share their memory with the host. Because of that, an initialization function is invoked by the Linker at instantiation time. This function takes care of setting up the whole environment.

Prior to this commit, this invocation would fail every time because the `wasmtime::Store` did not have any tick inside of it.

Just for reference, this behavior is explained [here](https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#start-section).

When looking at a Rego-based module, via `wasm-objdump`, the following output can be found (warning: function numbers change, based on the module):

The start section:

```
Start:
 - start function: 144
```

This would call function with ID `144`, which for this module is the following one:

```
- func[144] sig=0 <_initialize>
```

This fixes bug https://github.com/kubewarden/policy-server/issues/413

I've also bumped the patch versions of burrego and policy-evaluator. Once this PR gets merged I'll tag a new release of policy-evaluator and propagate this fix.
