### PR TITLE
fix rego evaluation when timeout protection is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.6.2"
+version = "0.6.3"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/crates/burrego/Cargo.toml
+++ b/crates/burrego/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrego"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2021"
 

--- a/crates/burrego/examples/cli/main.rs
+++ b/crates/burrego/examples/cli/main.rs
@@ -114,7 +114,7 @@ fn main() -> Result<()> {
             let (major, minor) = evaluator.opa_abi_version()?;
             debug!(major, minor, "OPA Wasm ABI");
 
-            let entrypoints = evaluator.entrypoints()?;
+            let entrypoints = evaluator.entrypoints();
             debug!(?entrypoints, "OPA entrypoints");
 
             let not_implemented_builtins = evaluator.not_implemented_builtins()?;


### PR DESCRIPTION
Sometimes the evaluation of a burrego policy led to a policy evaluation timeout.

This happened because, some parts of the code, forgot to add some ticks into the `wasmtime::Store` before invoking a wasm functions.

While working on that, I saved some static Rego data into the evaluator (like the entrypoints and the used builtins). By doing that we further reduce the invocations of wasm functions.

This fixes https://github.com/kubewarden/policy-evaluator/issues/239


**Note:** once this is merged, I'll tag a new release of policy-evaluator and bump that inside of Policy Server
