### PR TITLE
Limit the k8s resources that can be requested by a policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ json-patch = "0.3"
 kube = { version = "0.78.0", default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.17.0", default-features = false }
 #kubewarden-policy-sdk = "0.8.7"
-kubewarden-policy-sdk = { git = "https://github.com/flavio/policy-sdk-rust", branch = "context-aware" }
+kubewarden-policy-sdk = { git = "https://github.com/kubewarden/policy-sdk-rust", branch = "context-aware" }
 itertools = "0.10"
 lazy_static = "1.4"
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.18" }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,9 +1,11 @@
 use anyhow::Result;
 use std::clone::Clone;
+use std::collections::HashSet;
 use std::fmt;
 use tokio::sync::mpsc;
 
 use crate::callback_requests::CallbackRequest;
+use crate::policy_metadata::ContextAwareResource;
 
 /// Minimal amount of information about a policy that need to
 /// be always accessible at runtime.
@@ -27,6 +29,10 @@ pub struct Policy {
     /// to request the computation of code that can only be run inside of an
     /// asynchronous block
     pub callback_channel: Option<mpsc::Sender<CallbackRequest>>,
+
+    /// List of ContextAwareResource the policy is granted access to.
+    /// Currently, this is relevant only for waPC based policies
+    pub ctx_aware_resources_allow_list: HashSet<ContextAwareResource>,
 }
 
 impl fmt::Debug for Policy {
@@ -57,6 +63,7 @@ impl Default for Policy {
             id: String::default(),
             instance_id: None,
             callback_channel: None,
+            ctx_aware_resources_allow_list: HashSet::new(),
         }
     }
 }
@@ -66,11 +73,92 @@ impl Policy {
         id: String,
         policy_id: Option<u64>,
         callback_channel: Option<mpsc::Sender<CallbackRequest>>,
+        ctx_aware_resources_allow_list: Option<HashSet<ContextAwareResource>>,
     ) -> Result<Policy> {
         Ok(Policy {
             id,
             instance_id: policy_id,
             callback_channel,
+            ctx_aware_resources_allow_list: ctx_aware_resources_allow_list.unwrap_or_default(),
         })
+    }
+
+    pub(crate) fn can_access_kubernetes_resource(&self, api_version: &str, kind: &str) -> bool {
+        let wanted_resource = ContextAwareResource {
+            api_version: api_version.to_string(),
+            kind: kind.to_string(),
+        };
+
+        self.ctx_aware_resources_allow_list
+            .contains(&wanted_resource)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_access_kubernetes_resource_empty_allow_list() {
+        let policy =
+            Policy::new("test".to_string(), None, None, None).expect("cannot create policy");
+
+        let requested_resource = ContextAwareResource {
+            api_version: "v1".to_string(),
+            kind: "Secret".to_string(),
+        };
+
+        assert!(!policy.can_access_kubernetes_resource(
+            &requested_resource.api_version,
+            &requested_resource.kind
+        ));
+    }
+
+    #[test]
+    fn can_access_kubernetes_resource_denied() {
+        let requested_resource = ContextAwareResource {
+            api_version: "v1".to_string(),
+            kind: "Secret".to_string(),
+        };
+
+        let mut allowed_resources = HashSet::new();
+        allowed_resources.insert(ContextAwareResource {
+            api_version: "v1".to_string(),
+            kind: "Pod".to_string(),
+        });
+
+        let policy = Policy::new("test".to_string(), None, None, Some(allowed_resources))
+            .expect("cannot create policy");
+
+        assert!(!policy.can_access_kubernetes_resource(
+            &requested_resource.api_version,
+            &requested_resource.kind
+        ));
+    }
+
+    #[test]
+    fn can_access_kubernetes_resource_allowed() {
+        let requested_resource = ContextAwareResource {
+            api_version: "v1".to_string(),
+            kind: "Secret".to_string(),
+        };
+
+        let mut allowed_resources = HashSet::new();
+        allowed_resources.insert(ContextAwareResource {
+            api_version: "v1".to_string(),
+            kind: "Pod".to_string(),
+        });
+        allowed_resources.insert(ContextAwareResource {
+            api_version: "v1".to_string(),
+            kind: "Secret".to_string(),
+        });
+
+        let policy = Policy::new("test".to_string(), None, None, Some(allowed_resources))
+            .expect("cannot create policy");
+
+        assert!(policy.can_access_kubernetes_resource(
+            &requested_resource.api_version,
+            &requested_resource.kind
+        ));
     }
 }

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -142,6 +142,7 @@ pub struct Metadata {
     pub background_audit: bool,
     #[serde(default)]
     pub execution_mode: PolicyExecutionMode,
+    #[serde(default)]
     #[validate]
     pub context_aware_resources: HashSet<ContextAwareResource>,
 }


### PR DESCRIPTION
Limit the k8s resources that can be requested by a policy

Starting from this commit each policy has a list of Kubernetes resources that is allowed to access.

Any attempt to access a non allowed resource is going to be blocked and reported via the system logs.

