### PR TITLE
fix!: Serialize `ArtifactHubPkg{}` deterministically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "policy-evaluator"
 version = "0.7.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
-  "Rafael Fernández López <rfernandezlopez@suse.com>"
+  "Rafael Fernández López <rfernandezlopez@suse.com>",
+  "Víctor Cuadrado Juan <vcuadradojuan@suse.com>"
 ]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",

--- a/src/policy_artifacthub.rs
+++ b/src/policy_artifacthub.rs
@@ -3,7 +3,7 @@ use mail_parser::*;
 use policy_fetcher::oci_distribution::{ParseError, Reference};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 use time::OffsetDateTime;
 use url::Url;
@@ -70,7 +70,7 @@ pub struct ArtifactHubPkg {
     /// [{url: <url of kubewarden controller repo>}]
     recommendations: Vec<Recommendation>,
     /// List of annotations. Contains kubewarden-specific annotations
-    annotations: HashMap<String, String>,
+    annotations: BTreeMap<String, String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -403,9 +403,9 @@ fn parse_annotations(
     metadata_annots: &HashMap<String, String>,
     metadata: &Metadata,
     questions: Option<&str>,
-) -> Result<HashMap<String, String>> {
+) -> Result<BTreeMap<String, String>> {
     // add required annotations
-    let mut annotations: HashMap<String, String> = HashMap::new();
+    let mut annotations: BTreeMap<String, String> = BTreeMap::new();
     annotations.insert(
         ARTIFACTHUB_ANNOTATION_KUBEWARDEN_MUTATION.to_string(),
         metadata.mutating.to_string(),

--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -11,20 +11,15 @@ use crate::runtimes::burrego::Runtime as BurregoRuntime;
 use crate::runtimes::wapc::Runtime as WapcRuntime;
 use crate::runtimes::Runtime;
 
-#[derive(Copy, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Default, serde::Deserialize, serde::Serialize, Debug)]
 pub enum PolicyExecutionMode {
     #[serde(rename = "kubewarden-wapc")]
+    #[default]
     KubewardenWapc,
     #[serde(rename = "opa")]
     Opa,
     #[serde(rename = "gatekeeper")]
     OpaGatekeeper,
-}
-
-impl Default for PolicyExecutionMode {
-    fn default() -> Self {
-        PolicyExecutionMode::KubewardenWapc
-    }
 }
 
 impl fmt::Display for PolicyExecutionMode {


### PR DESCRIPTION
## Description

fix!: Serialize `ArtifactHubPkg{}` deterministically, by using a `BTreeMap{}` for the annotations. 
build: Bump version to 0.8.0.
build: Add Victor to authors.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

By CI.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

Needed for kwctl scaffold comparisons.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Alternative: Use [IndexMap](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html), but then we add dependencies.
