### PR TITLE
refactor: derive Eq traits against some structs

### DIFF
--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -26,7 +26,7 @@ pub struct CallbackRequest {
 
 /// Describes the different kinds of request a waPC guest can make to
 /// our host.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub enum CallbackRequestType {
     /// Require the computation of the manifest digest of an OCI object (be
     /// it an image or anything else that can be stored into an OCI registry)


### PR DESCRIPTION
This is required by the context aware feature, more specifically by the new callback handler proxy

This PR depends on https://github.com/kubewarden/policy-sdk-rust/pull/83

The test suite will keep failing until this gets merged