### PR TITLE
feat: Set ArtifactHubPkg{}.install field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",


### PR DESCRIPTION
## Description

Fill it with the OCI URL as we were doing so far. E.g:

    The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
    ```console
    kwctl pull ghcr.io/ocirepo/namespace/verify-image-signatures:v0.2.1
    ```

We forgot to fill this, looking at [the RFC](https://github.com/kubewarden/rfc/blob/main/rfc/0014-metadata.md).

This will need a new release to be consumed by kwctl in 1.6.0-rc3

## Test

Amended unit tests.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

We could expand it with instructions to do a `kwctl scaffold clusteradmissionpolicy` or the like. I welcome suggestions.
