### PR TITLE
Minimum Kubewarden version field.

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -161,4 +161,24 @@ mod tests {
             &requested_resource.kind
         ));
     }
+
+    #[test]
+    fn policy_fields_test() {
+        let id = "test".to_string();
+        let policy_id = Some(1);
+        let callback_channel = None;
+        let ctx_aware_resources_allow_list = Some(HashSet::new());
+
+        let policy = Policy::new(
+            id.clone(),
+            policy_id.clone(),
+            callback_channel.clone(),
+            ctx_aware_resources_allow_list.clone(),
+        )
+        .expect("cannot create policy");
+
+        assert!(policy.id == id);
+        assert!(policy.instance_id == policy_id);
+        assert!(policy.ctx_aware_resources_allow_list == ctx_aware_resources_allow_list.unwrap());
+    }
 }

--- a/src/policy_artifacthub.rs
+++ b/src/policy_artifacthub.rs
@@ -522,6 +522,7 @@ mod tests {
             background_audit: true,
             context_aware_resources: HashSet::new(),
             execution_mode: Default::default(),
+            minimum_kubewarden_version: None,
         }
     }
 
@@ -585,6 +586,7 @@ mod tests {
             background_audit: true,
             context_aware_resources,
             execution_mode: Default::default(),
+            minimum_kubewarden_version: None,
         }
     }
 

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use kubewarden_policy_sdk::metadata::ProtocolVersion;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -145,6 +146,8 @@ pub struct Metadata {
     #[serde(default)]
     #[validate]
     pub context_aware_resources: HashSet<ContextAwareResource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum_kubewarden_version: Option<Version>,
 }
 
 const fn _default_true() -> bool {
@@ -161,6 +164,7 @@ impl Default for Metadata {
             background_audit: true,
             execution_mode: PolicyExecutionMode::KubewardenWapc,
             context_aware_resources: HashSet::new(),
+            minimum_kubewarden_version: None,
         }
     }
 }


### PR DESCRIPTION
## Description

Adds in the Policy struct a new field to store the minimum version of the Kubewarden stack required to run the policy.

Fix #267 

## Test

```shell
make test
```