### PR TITLE
chore(deps): update policy-fetcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.9.3"
+version = "0.9.4"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",
@@ -25,7 +25,7 @@ k8s-openapi = { version = "0.18.0", default-features = false }
 kubewarden-policy-sdk = "0.9.4"
 itertools = "0.10"
 lazy_static = "1.4"
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.20" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.7.21" }
 serde_json = "1.0"
 serde_yaml = "0.9"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This is required to use latest version of sigstore

Once merged I'll tag a new release

