### PR TITLE
feat: introduce WASI policies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ url = { version = "2.2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 wasmparser = "0.107"
 wapc = "1.0.0"
+wasmtime          = "9.0"
+wasmtime-wasi     = "9.0"
+wasi-common       = "9.0"
+wasi-cap-std-sync = "9.0"
 wasmtime-provider = { version = "1.6.0", features = ["cache"] }
 picky = { version = "7.0.0-rc.5", default-features = false, features = [ "x509", "ec", "chrono_conversion" ] }
 chrono = "0.4.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-evaluator"
-version = "0.9.4"
+version = "0.9.5"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",

--- a/src/runtimes/mod.rs
+++ b/src/runtimes/mod.rs
@@ -1,7 +1,9 @@
 pub mod burrego;
 pub(crate) mod wapc;
+pub(crate) mod wasi_cli;
 
 pub(crate) enum Runtime {
     Wapc(wapc::WapcStack),
     Burrego(burrego::BurregoStack),
+    Cli(wasi_cli::Stack),
 }

--- a/src/runtimes/wasi_cli/errors.rs
+++ b/src/runtimes/wasi_cli/errors.rs
@@ -1,0 +1,23 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum WasiRuntimeError {
+    #[error("cannot set wasi args")]
+    WasiStringArray(#[from] wasi_common::StringArrayError),
+
+    #[error("program exited with code {code:?}; stderr set to '{stderr}', error: '{error}'")]
+    WasiEvaluation {
+        code: Option<i32>,
+        stderr: String,
+        error: wasmtime::Error,
+    },
+
+    #[error("cannot instantiate module: {0}")]
+    WasmInstantiate(wasmtime::Error),
+
+    #[error("cannot find `_start` function inside of module: {0}")]
+    WasmMissingStartFn(wasmtime::Error),
+
+    #[error("{name} pipe conversion error: {error}")]
+    PipeConversion { name: String, error: String },
+}

--- a/src/runtimes/wasi_cli/mod.rs
+++ b/src/runtimes/wasi_cli/mod.rs
@@ -1,0 +1,6 @@
+mod errors;
+mod runtime;
+mod stack;
+
+pub(crate) use runtime::Runtime;
+pub(crate) use stack::Stack;

--- a/src/runtimes/wasi_cli/runtime.rs
+++ b/src/runtimes/wasi_cli/runtime.rs
@@ -1,0 +1,187 @@
+use kubewarden_policy_sdk::response::ValidationResponse as PolicyValidationResponse;
+use kubewarden_policy_sdk::settings::SettingsValidationResponse;
+use serde_json::json;
+use std::io::Cursor;
+use tracing::{error, warn};
+use wasi_common::pipe::{ReadPipe, WritePipe};
+use wasmtime_wasi::sync::WasiCtxBuilder;
+
+use super::{errors::WasiRuntimeError, stack};
+use crate::admission_response::AdmissionResponse;
+use crate::policy_evaluator::{PolicySettings, ValidateRequest};
+
+const EXIT_SUCCESS: i32 = 0;
+
+pub(crate) struct Runtime<'a>(pub(crate) &'a mut stack::Stack);
+
+struct ExcutionResult {
+    stdout: String,
+    stderr: String,
+}
+
+impl<'a> Runtime<'a> {
+    /// executes the wasi cli program
+    fn execute(
+        &mut self,
+        input: Vec<u8>,
+        args: &[String],
+    ) -> std::result::Result<ExcutionResult, WasiRuntimeError> {
+        let stdout_pipe = WritePipe::new_in_memory();
+        let stderr_pipe = WritePipe::new_in_memory();
+        let stdin_pipe = ReadPipe::new(Cursor::new(input));
+
+        let wasi_ctx = WasiCtxBuilder::new()
+            .args(args)?
+            .stdin(Box::new(stdin_pipe))
+            .stdout(Box::new(stdout_pipe.clone()))
+            .stderr(Box::new(stderr_pipe.clone()))
+            .build();
+        let ctx = stack::Context { wasi_ctx };
+
+        let mut store = wasmtime::Store::new(&self.0.engine, ctx);
+        if let Some(deadline) = self.0.epoch_deadlines {
+            store.set_epoch_deadline(deadline.wapc_func);
+        }
+
+        let instance = self
+            .0
+            .instance_pre
+            .instantiate(&mut store)
+            .map_err(WasiRuntimeError::WasmInstantiate)?;
+        let start_fn = instance
+            .get_typed_func::<(), ()>(&mut store, "_start")
+            .map_err(WasiRuntimeError::WasmMissingStartFn)?;
+        let evaluation_result = start_fn.call(&mut store, ());
+
+        // Dropping the store, this is no longer needed, plus it's keeping
+        // references to the WritePipe(s) that we need exclusive access to.
+        drop(store);
+
+        let stderr = pipe_to_string("stderr", stderr_pipe)?;
+
+        if let Err(err) = evaluation_result {
+            if let Some(exit_error) = err.downcast_ref::<wasmtime_wasi::I32Exit>() {
+                if exit_error.0 == EXIT_SUCCESS {
+                    let stdout = pipe_to_string("stdout", stdout_pipe)?;
+                    return Ok(ExcutionResult { stdout, stderr });
+                } else {
+                    return Err(WasiRuntimeError::WasiEvaluation {
+                        code: Some(exit_error.0),
+                        stderr,
+                        error: err,
+                    });
+                }
+            }
+            return Err(WasiRuntimeError::WasiEvaluation {
+                code: None,
+                stderr,
+                error: err,
+            });
+        }
+
+        let stdout = pipe_to_string("stdout", stdout_pipe)?;
+        Ok(ExcutionResult { stdout, stderr })
+    }
+
+    pub fn validate(
+        &mut self,
+        settings: &PolicySettings,
+        request: &ValidateRequest,
+    ) -> AdmissionResponse {
+        let validate_params = json!({
+            "request": request,
+            "settings": settings,
+        });
+
+        let input = match serde_json::to_vec(&validate_params) {
+            Ok(s) => s,
+            Err(e) => {
+                error!(
+                    error = e.to_string().as_str(),
+                    "cannot serialize validation params"
+                );
+                return AdmissionResponse::reject_internal_server_error(
+                    request.uid().to_string(),
+                    e.to_string(),
+                );
+            }
+        };
+        let args = vec!["policy.wasm".to_string(), "validate".to_string()];
+
+        match self.execute(input, &args) {
+            Ok(ExcutionResult { stdout, stderr }) => {
+                if !stderr.is_empty() {
+                    warn!(
+                        request = request.uid().to_string(),
+                        operation = "validate",
+                        "stderr: {:?}",
+                        stderr
+                    )
+                }
+                match serde_json::from_slice::<PolicyValidationResponse>(stdout.as_bytes()) {
+                    Ok(pvr) => AdmissionResponse::from_policy_validation_response(
+                        request.uid().to_string(),
+                        request.0.get("object"),
+                        &pvr,
+                    )
+                    .unwrap_or_else(|e| {
+                        AdmissionResponse::reject_internal_server_error(
+                            request.uid().to_string(),
+                            format!("Cannot convert policy validation response: {e}"),
+                        )
+                    }),
+                    Err(e) => AdmissionResponse::reject_internal_server_error(
+                        request.uid().to_string(),
+                        format!("Cannot deserialize policy validation response: {e}"),
+                    ),
+                }
+            }
+            Err(e) => AdmissionResponse::reject_internal_server_error(
+                request.uid().to_string(),
+                e.to_string(),
+            ),
+        }
+    }
+
+    pub fn validate_settings(&mut self, settings: String) -> SettingsValidationResponse {
+        let args = vec!["policy.wasm".to_string(), "validate-settings".to_string()];
+
+        match self.execute(settings.as_bytes().to_owned(), &args) {
+            Ok(ExcutionResult { stdout, stderr }) => {
+                if !stderr.is_empty() {
+                    warn!(operation = "validate-settings", "stderr: {:?}", stderr)
+                }
+                serde_json::from_slice::<SettingsValidationResponse>(stdout.as_bytes())
+                    .unwrap_or_else(|e| SettingsValidationResponse {
+                        valid: false,
+                        message: Some(format!(
+                            "Cannot deserialize settings validation response: {e}"
+                        )),
+                    })
+            }
+            Err(e) => SettingsValidationResponse {
+                valid: false,
+                message: Some(e.to_string()),
+            },
+        }
+    }
+}
+
+fn pipe_to_string(
+    name: &str,
+    pipe: WritePipe<Cursor<Vec<u8>>>,
+) -> std::result::Result<String, WasiRuntimeError> {
+    match pipe.try_into_inner() {
+        Ok(cursor) => {
+            let buf = cursor.into_inner();
+            String::from_utf8(buf).map_err(|e| WasiRuntimeError::PipeConversion {
+                name: name.to_string(),
+                error: format!("Cannot convert buffer to UTF8 string: {e}"),
+            })
+        }
+        Err(_) => Err(WasiRuntimeError::PipeConversion {
+            name: name.to_string(),
+            error: "cannot convert pipe into inner".to_string(),
+        }),
+    }
+}

--- a/src/runtimes/wasi_cli/stack.rs
+++ b/src/runtimes/wasi_cli/stack.rs
@@ -1,0 +1,33 @@
+use crate::policy_evaluator_builder::EpochDeadlines;
+use anyhow::Result;
+use wasi_common::WasiCtx;
+use wasmtime::{Engine, InstancePre, Linker, Module};
+
+pub(crate) struct Context {
+    pub(crate) wasi_ctx: WasiCtx,
+}
+
+pub(crate) struct Stack {
+    pub(crate) engine: Engine,
+    pub(crate) epoch_deadlines: Option<EpochDeadlines>,
+    pub(crate) instance_pre: InstancePre<Context>,
+}
+
+impl Stack {
+    pub(crate) fn new(
+        engine: Engine,
+        module: Module,
+        epoch_deadlines: Option<EpochDeadlines>,
+    ) -> Result<Self> {
+        let mut linker = Linker::<Context>::new(&engine);
+        wasmtime_wasi::add_to_linker(&mut linker, |c: &mut Context| &mut c.wasi_ctx)?;
+
+        let instance_pre = linker.instantiate_pre(&module)?;
+
+        Ok(Stack {
+            engine,
+            instance_pre,
+            epoch_deadlines,
+        })
+    }
+}


### PR DESCRIPTION
Introduce a new type of policy execution mode: this runs WASI programs and leverages STDIN, STDOUT and STDERR as a way to communicate with the policy.

This allows policies written with the official Go compiler to be used. The Go compiler isn't able to produce WASM modules that `export` functions. This makes not possible the usage of waPC.

This is a known issue that is going to be addressed with future releases of the Go compiler. In the meantime, thanks to this PR, we will be able to write policies using the new Go compiler
