### PR TITLE
feat: Expand install msg on artifacthub

### DIFF
--- a/src/policy_artifacthub.rs
+++ b/src/policy_artifacthub.rs
@@ -375,6 +375,10 @@ fn compose_install(oci_url: String) -> String {
 ```console
 kwctl pull {}
 ```
+Then, generate the policy manifest and tune it to your liking. For example:
+```console
+kwctl scaffold manifest -t ClusterAdmissionPolicy registry://{}
+```
 "#,
         oci_url
     )


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
I find the install modal on artifacthub lacking:

https://artifacthub.io/packages/kubewarden/safe-annotations/safe-annotations?modal=install

This is an attempt to improve it, as I was typing too much on my own.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
