### PR TITLE
automation(renovate): pin GH actions by digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    "schedule:earlyMondays"
+    "schedule:earlyMondays",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": ["dependencies"],
   "lockFileMaintenance": { "enabled": true },


### PR DESCRIPTION
Configure renovate bot to pin GH actions using their digest, as documented [here](https://docs.renovatebot.com/modules/manager/github-actions/#additional-information)
