### PR TITLE
Small cleanups

### DIFF
--- a/src/policy_evaluator_builder.rs
+++ b/src/policy_evaluator_builder.rs
@@ -266,7 +266,7 @@ impl PolicyEvaluatorBuilder {
 
                 let policy = Self::from_contents_internal(
                     self.policy_id.clone(),
-                    self.callback_channel.clone(),
+                    None, // callback_channel is not used by WASI policies
                     None,
                     || None,
                     Policy::new,
@@ -279,7 +279,7 @@ impl PolicyEvaluatorBuilder {
             PolicyExecutionMode::Opa | PolicyExecutionMode::OpaGatekeeper => {
                 let policy = Self::from_contents_internal(
                     self.policy_id.clone(),
-                    self.callback_channel.clone(),
+                    None, // callback_channel is not used by Rego policies
                     None,
                     || None,
                     Policy::new,

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -353,8 +353,12 @@ fn send_request_and_wait_for_response(
     req: CallbackRequest,
     mut rx: Receiver<Result<CallbackResponse>>,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-    let policy_mapping = WAPC_POLICY_MAPPING.read().unwrap();
-    let policy = policy_mapping.get(&policy_id).unwrap();
+    let policy_mapping = WAPC_POLICY_MAPPING
+        .read()
+        .map_err(|e| anyhow!("cannot get READ access to WAPC_POLICY_MAPPING: {e}"))?;
+    let policy = policy_mapping
+        .get(&policy_id)
+        .ok_or(anyhow!("cannot find policy with id {policy_id}"))?;
 
     let cb_channel: mpsc::Sender<CallbackRequest> = if let Some(c) = policy.callback_channel.clone()
     {

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -491,6 +491,20 @@ impl WapcStack {
     }
 }
 
+impl Drop for WapcStack {
+    fn drop(&mut self) {
+        // ensure we clean this entry from the WAPC_POLICY_MAPPING mapping
+        match WAPC_POLICY_MAPPING.write() {
+            Ok(mut map) => {
+                map.remove(&self.wapc_host.id());
+            }
+            Err(_) => {
+                warn!("cannot cleanup policy from WAPC_POLICY_MAPPING");
+            }
+        }
+    }
+}
+
 impl<'a> Runtime<'a> {
     pub fn validate(
         &mut self,


### PR DESCRIPTION
- fix: avoid allocation of callback channel: Neither the Rego, nor the WASI policies make use of host callbackes.
  Hence, we can avoid to clone the callback channel required to interact
  with the host.
- fix: avoid usage of `unwrap`: Avoid usage of unwrap when trying to acquire write/read access to the
  waPC ReadWriteMutex. This kind of errors should not happen, but when
  they do it would be better to bubble up the error instead of having a
  panic.
- fix: implement cleanup for WapcStack: Remove from the WaPC policy mapping dictionary a policy that has been removed from the program stack.
