### PR TITLE
feat: raw policy validation

### DIFF
--- a/src/admission_request.rs
+++ b/src/admission_request.rs
@@ -1,3 +1,4 @@
+/// This models the admission/v1/AdmissionRequest object of Kubernetes
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AdmissionRequest {

--- a/src/admission_request.rs
+++ b/src/admission_request.rs
@@ -1,0 +1,43 @@
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdmissionRequest {
+    pub uid: String,
+    pub kind: GroupVersionKind,
+    pub resource: GroupVersionResource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sub_resource: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_kind: Option<GroupVersionKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_resource: Option<GroupVersionResource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_sub_resource: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    pub operation: String,
+    pub user_info: k8s_openapi::api::authentication::v1::UserInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object: Option<k8s_openapi::apimachinery::pkg::runtime::RawExtension>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_object: Option<k8s_openapi::apimachinery::pkg::runtime::RawExtension>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dry_run: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<k8s_openapi::apimachinery::pkg::runtime::RawExtension>,
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct GroupVersionKind {
+    pub group: String,
+    pub version: String,
+    pub kind: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct GroupVersionResource {
+    pub group: String,
+    pub version: String,
+    pub resource: String,
+}

--- a/src/admission_response.rs
+++ b/src/admission_response.rs
@@ -147,7 +147,7 @@ mod tests {
 
         let response = AdmissionResponse::reject(uid.clone(), message.clone(), code);
         assert_eq!(response.uid, uid);
-        assert_eq!(response.allowed, false);
+        assert!(!response.allowed);
         assert_eq!(response.patch, None);
         assert_eq!(response.patch_type, None);
 
@@ -187,7 +187,7 @@ mod tests {
         let response = response.unwrap();
 
         assert_eq!(response.uid, uid);
-        assert_eq!(response.allowed, false);
+        assert!(!response.allowed);
         assert_eq!(response.patch, None);
         assert_eq!(response.patch_type, None);
         assert_eq!(response.audit_annotations, Some(audit_annotations));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub extern crate burrego;
 extern crate wasmparser;
 
+pub mod admission_request;
 pub mod admission_response;
 pub mod callback_handler;
 pub mod callback_requests;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -13,7 +13,7 @@ use crate::policy_metadata::ContextAwareResource;
 /// This struct is used extensively inside of the `host_callback`
 /// function to obtain information about the policy that is invoking
 /// a host waPC function, and handle the request.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Policy {
     /// The policy identifier. This is mostly relevant for Policy Server,
     /// which uses the identifier provided by the user inside of the `policy.yml`
@@ -53,18 +53,6 @@ impl fmt::Debug for Policy {
 impl PartialEq for Policy {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id && self.instance_id == other.instance_id
-    }
-}
-
-#[cfg(test)]
-impl Default for Policy {
-    fn default() -> Self {
-        Policy {
-            id: String::default(),
-            instance_id: None,
-            callback_channel: None,
-            ctx_aware_resources_allow_list: HashSet::new(),
-        }
     }
 }
 
@@ -167,18 +155,18 @@ mod tests {
         let id = "test".to_string();
         let policy_id = Some(1);
         let callback_channel = None;
-        let ctx_aware_resources_allow_list = Some(HashSet::new());
+        let ctx_aware_resources_allow_list = HashSet::new();
 
         let policy = Policy::new(
             id.clone(),
-            policy_id.clone(),
+            policy_id,
             callback_channel.clone(),
-            ctx_aware_resources_allow_list.clone(),
+            Some(ctx_aware_resources_allow_list.clone()),
         )
         .expect("cannot create policy");
 
         assert!(policy.id == id);
         assert!(policy.instance_id == policy_id);
-        assert!(policy.ctx_aware_resources_allow_list == ctx_aware_resources_allow_list.unwrap());
+        assert!(policy.ctx_aware_resources_allow_list == ctx_aware_resources_allow_list);
     }
 }

--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -199,7 +199,7 @@ mod tests {
 
         for (mode_str, expected) in &test_data {
             let actual: std::result::Result<PolicyExecutionMode, serde_json::Error> =
-                serde_json::from_str(&mode_str);
+                serde_json::from_str(mode_str);
             assert_eq!(expected, &actual.unwrap());
         }
 

--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -33,6 +33,8 @@ impl fmt::Display for PolicyExecutionMode {
     }
 }
 
+/// A validation request that can be sent to a policy evaluator.
+/// It can be either a raw JSON object, or a Kubernetes AdmissionRequest.
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 pub enum ValidateRequest {

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn metadata_with_rego_execution_mode_must_have_a_valid_protocol() {
-        for mode in vec![PolicyExecutionMode::Opa, PolicyExecutionMode::OpaGatekeeper] {
+        for mode in [PolicyExecutionMode::Opa, PolicyExecutionMode::OpaGatekeeper] {
             let metadata = Metadata {
                 protocol_version: Some(ProtocolVersion::Unknown),
                 execution_mode: mode,

--- a/src/runtimes/wapc.rs
+++ b/src/runtimes/wapc.rs
@@ -513,8 +513,14 @@ impl<'a> Runtime<'a> {
     ) -> AdmissionResponse {
         let uid = request.uid();
 
+        let req_json_value =
+            serde_json::to_value(request).expect("cannot convert request to json value");
+
         //NOTE: object is null for DELETE operations
-        let req_obj = request.0.get("object");
+        let req_obj = match request {
+            ValidateRequest::Raw(_) => Some(&req_json_value),
+            ValidateRequest::AdmissionRequest(_) => req_json_value.get("object"),
+        };
 
         let validate_params = json!({
             "request": request,


### PR DESCRIPTION
## Description

Change the policy evaluator and the existing runtimes to support "raw" policy requests.
Raw requests are generic requests that are not in the form of Kubernetes AdmissionRequests.
The AdmissionRequest type has been moved from the policy-server to this repo, which already contains the AdmissionResponse type.

The ValidatieRequest type has been refactored into an Enum type to support the new variant and runtimes have been changed accordingly.
The only exception is the Gatekeeper execution mode, being Gatekeeper k8s only by nature.

Note that we are still using the AdmissionResponse type as the return type of an evaluation since it is generic enough. The only difference is that we will not wrap it inside an AdmissionReview in the policy server if the user has requested a raw policy validation.

Related to: https://github.com/kubewarden/kubewarden-controller/issues/527

## Test
Since the current testing is structured this way, most of the tests are done in the policy-server e2e tests.
We could improve this by adding runtime-related integration tests inside this crate.

See: https://github.com/kubewarden/policy-evaluator/issues/358

## Additional Information

### Tradeoff

