### PR TITLE
fix: pretty print of policy type

### DIFF
--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -141,7 +141,7 @@ pub enum PolicyType {
 impl Display for PolicyType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let json = serde_json::to_string(self).map_err(|_| fmt::Error {})?;
-        write!(f, "{}", json)
+        write!(f, "{}", json.replace('"', ""))
     }
 }
 


### PR DESCRIPTION
Remove the extra quotes shown when displaying the policy type (raw/kubernetes).

Prior to this PR:

```console
policy type:                  "kubernetes"
```

After this PR:

```console
policy type:                  kubernetes
```
