### PR TITLE
refactor: Make Rego inventories deterministically ordered with BTreeMap

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use std::clone::Clone;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt;
 use tokio::sync::mpsc;
 
@@ -32,7 +32,7 @@ pub struct Policy {
 
     /// List of ContextAwareResource the policy is granted access to.
     /// Currently, this is relevant only for waPC based policies
-    pub ctx_aware_resources_allow_list: HashSet<ContextAwareResource>,
+    pub ctx_aware_resources_allow_list: BTreeSet<ContextAwareResource>,
 }
 
 impl fmt::Debug for Policy {
@@ -61,7 +61,7 @@ impl Policy {
         id: String,
         policy_id: Option<u64>,
         callback_channel: Option<mpsc::Sender<CallbackRequest>>,
-        ctx_aware_resources_allow_list: Option<HashSet<ContextAwareResource>>,
+        ctx_aware_resources_allow_list: Option<BTreeSet<ContextAwareResource>>,
     ) -> Result<Policy> {
         Ok(Policy {
             id,
@@ -109,7 +109,7 @@ mod tests {
             kind: "Secret".to_string(),
         };
 
-        let mut allowed_resources = HashSet::new();
+        let mut allowed_resources = BTreeSet::new();
         allowed_resources.insert(ContextAwareResource {
             api_version: "v1".to_string(),
             kind: "Pod".to_string(),
@@ -131,7 +131,7 @@ mod tests {
             kind: "Secret".to_string(),
         };
 
-        let mut allowed_resources = HashSet::new();
+        let mut allowed_resources = BTreeSet::new();
         allowed_resources.insert(ContextAwareResource {
             api_version: "v1".to_string(),
             kind: "Pod".to_string(),
@@ -155,7 +155,7 @@ mod tests {
         let id = "test".to_string();
         let policy_id = Some(1);
         let callback_channel = None;
-        let ctx_aware_resources_allow_list = HashSet::new();
+        let ctx_aware_resources_allow_list = BTreeSet::new();
 
         let policy = Policy::new(
             id.clone(),

--- a/src/policy_artifacthub.rs
+++ b/src/policy_artifacthub.rs
@@ -477,7 +477,7 @@ mod tests {
     use crate::policy_metadata::{ContextAwareResource, PolicyType};
     use assert_json_diff::assert_json_eq;
     use serde_json::json;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{BTreeSet, HashMap};
 
     fn mock_metadata_with_minimum_required() -> Metadata {
         Metadata {
@@ -507,7 +507,7 @@ mod tests {
             ])),
             mutating: false,
             background_audit: true,
-            context_aware_resources: HashSet::new(),
+            context_aware_resources: BTreeSet::new(),
             execution_mode: Default::default(),
             policy_type: PolicyType::Kubernetes,
             minimum_kubewarden_version: None,
@@ -515,7 +515,7 @@ mod tests {
     }
 
     fn mock_metadata_with_all() -> Metadata {
-        let mut context_aware_resources: HashSet<ContextAwareResource> = HashSet::new();
+        let mut context_aware_resources: BTreeSet<ContextAwareResource> = BTreeSet::new();
         context_aware_resources.insert(ContextAwareResource {
             api_version: "v1".to_string(),
             kind: "Pod".to_string(),

--- a/src/policy_evaluator_builder.rs
+++ b/src/policy_evaluator_builder.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::path::Path;
 use tokio::sync::mpsc;
@@ -41,7 +41,7 @@ pub struct PolicyEvaluatorBuilder {
     callback_channel: Option<mpsc::Sender<CallbackRequest>>,
     wasmtime_cache: bool,
     epoch_deadlines: Option<EpochDeadlines>,
-    ctx_aware_resources_allow_list: HashSet<ContextAwareResource>,
+    ctx_aware_resources_allow_list: BTreeSet<ContextAwareResource>,
 }
 
 impl PolicyEvaluatorBuilder {
@@ -115,7 +115,7 @@ impl PolicyEvaluatorBuilder {
     /// Set the list of Kubernetes resources the policy can have access to
     pub fn context_aware_resources_allowed(
         mut self,
-        allowed_resources: HashSet<ContextAwareResource>,
+        allowed_resources: BTreeSet<ContextAwareResource>,
     ) -> PolicyEvaluatorBuilder {
         self.ctx_aware_resources_allow_list = allowed_resources;
         self
@@ -316,7 +316,7 @@ impl PolicyEvaluatorBuilder {
     fn from_contents_internal<E, P>(
         id: String,
         callback_channel: Option<mpsc::Sender<CallbackRequest>>,
-        ctx_aware_resources_allow_list: Option<HashSet<ContextAwareResource>>,
+        ctx_aware_resources_allow_list: Option<BTreeSet<ContextAwareResource>>,
         engine_initializer: E,
         policy_initializer: P,
         policy_execution_mode: PolicyExecutionMode,
@@ -327,7 +327,7 @@ impl PolicyEvaluatorBuilder {
             String,
             Option<u64>,
             Option<mpsc::Sender<CallbackRequest>>,
-            Option<HashSet<ContextAwareResource>>,
+            Option<BTreeSet<ContextAwareResource>>,
         ) -> Result<Policy>,
     {
         let instance_id = engine_initializer();

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -120,7 +120,7 @@ fn validate_resources(data: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Validate, PartialEq, Hash, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Validate, PartialEq, Hash, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub struct ContextAwareResource {
     #[validate(length(min = 1))]

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use kubewarden_policy_sdk::metadata::ProtocolVersion;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::{self, Display};
 use std::path::Path;
 use validator::{Validate, ValidationError};
@@ -164,7 +164,7 @@ pub struct Metadata {
     pub policy_type: PolicyType,
     #[serde(default)]
     #[validate]
-    pub context_aware_resources: HashSet<ContextAwareResource>,
+    pub context_aware_resources: BTreeSet<ContextAwareResource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minimum_kubewarden_version: Option<Version>,
 }
@@ -183,7 +183,7 @@ impl Default for Metadata {
             background_audit: true,
             execution_mode: PolicyExecutionMode::KubewardenWapc,
             policy_type: PolicyType::Kubernetes,
-            context_aware_resources: HashSet::new(),
+            context_aware_resources: BTreeSet::new(),
             minimum_kubewarden_version: None,
         }
     }
@@ -389,7 +389,7 @@ mod tests {
             protocol_version: Some(ProtocolVersion::V1),
             annotations: None,
             background_audit: true,
-            context_aware_resources: HashSet::new(),
+            context_aware_resources: BTreeSet::new(),
             policy_type: PolicyType::Kubernetes,
             ..Default::default()
         };
@@ -619,7 +619,7 @@ mod tests {
             String::from("Flavio Castelli"),
         );
 
-        let mut context_aware_resources = HashSet::new();
+        let mut context_aware_resources = BTreeSet::new();
         context_aware_resources.insert(ContextAwareResource {
             api_version: "".to_string(),
             kind: "Pod".to_string(),
@@ -643,7 +643,7 @@ mod tests {
             String::from("Flavio Castelli"),
         );
 
-        let mut context_aware_resources = HashSet::new();
+        let mut context_aware_resources = BTreeSet::new();
         context_aware_resources.insert(ContextAwareResource {
             api_version: "v1".to_string(),
             kind: "".to_string(),

--- a/src/runtimes/rego/context_aware.rs
+++ b/src/runtimes/rego/context_aware.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
     callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse},
@@ -24,7 +24,7 @@ pub(crate) enum KubernetesContext {
 /// used by the runtime.
 pub(crate) fn get_allowed_resources(
     callback_channel: &mpsc::Sender<CallbackRequest>,
-    allowed_resources: &HashSet<ContextAwareResource>,
+    allowed_resources: &BTreeSet<ContextAwareResource>,
 ) -> Result<BTreeMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>>> {
     let mut kube_resources: BTreeMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>> =
         BTreeMap::new();
@@ -59,7 +59,7 @@ fn get_all_resources_by_type(
 /// The map is built by making request via the given callback channel.
 pub(crate) fn get_plural_names(
     callback_channel: &mpsc::Sender<CallbackRequest>,
-    allowed_resources: &HashSet<ContextAwareResource>,
+    allowed_resources: &BTreeSet<ContextAwareResource>,
 ) -> Result<BTreeMap<ContextAwareResource, String>> {
     let mut plural_names_by_resource: BTreeMap<ContextAwareResource, String> = BTreeMap::new();
 
@@ -211,7 +211,7 @@ pub(crate) mod tests {
         };
         let plural_name = "services";
 
-        let mut resources: HashSet<ContextAwareResource> = HashSet::new();
+        let mut resources: BTreeSet<ContextAwareResource> = BTreeSet::new();
         resources.insert(resource.clone());
 
         let mut expected_names: BTreeMap<ContextAwareResource, String> = BTreeMap::new();

--- a/src/runtimes/rego/context_aware.rs
+++ b/src/runtimes/rego/context_aware.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use crate::{
     callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse},
@@ -25,9 +25,9 @@ pub(crate) enum KubernetesContext {
 pub(crate) fn get_allowed_resources(
     callback_channel: &mpsc::Sender<CallbackRequest>,
     allowed_resources: &HashSet<ContextAwareResource>,
-) -> Result<HashMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>>> {
-    let mut kube_resources: HashMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>> =
-        HashMap::new();
+) -> Result<BTreeMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>>> {
+    let mut kube_resources: BTreeMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>> =
+        BTreeMap::new();
 
     for resource in allowed_resources {
         let resource_list = get_all_resources_by_type(callback_channel, resource)?;
@@ -60,8 +60,8 @@ fn get_all_resources_by_type(
 pub(crate) fn get_plural_names(
     callback_channel: &mpsc::Sender<CallbackRequest>,
     allowed_resources: &HashSet<ContextAwareResource>,
-) -> Result<HashMap<ContextAwareResource, String>> {
-    let mut plural_names_by_resource: HashMap<ContextAwareResource, String> = HashMap::new();
+) -> Result<BTreeMap<ContextAwareResource, String>> {
+    let mut plural_names_by_resource: BTreeMap<ContextAwareResource, String> = BTreeMap::new();
 
     for resource in allowed_resources {
         let req_type = CallbackRequestType::KubernetesGetResourcePluralName {
@@ -214,7 +214,7 @@ pub(crate) mod tests {
         let mut resources: HashSet<ContextAwareResource> = HashSet::new();
         resources.insert(resource.clone());
 
-        let mut expected_names: HashMap<ContextAwareResource, String> = HashMap::new();
+        let mut expected_names: BTreeMap<ContextAwareResource, String> = BTreeMap::new();
         expected_names.insert(resource.clone(), plural_name.to_string());
 
         let expected_resource = resource.clone();

--- a/src/runtimes/rego/gatekeeper_inventory.rs
+++ b/src/runtimes/rego/gatekeeper_inventory.rs
@@ -58,12 +58,12 @@ use crate::policy_metadata::ContextAwareResource;
 use anyhow::{anyhow, Result};
 use kube::api::ObjectList;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// A wrapper around a dictionary that has the resource Name as key,
 /// and a DynamicObject as value
 #[derive(Serialize, Default)]
-pub(crate) struct ResourcesByName(HashMap<String, kube::core::DynamicObject>);
+pub(crate) struct ResourcesByName(BTreeMap<String, kube::core::DynamicObject>);
 
 impl ResourcesByName {
     fn register(&mut self, obj: &kube::core::DynamicObject) -> Result<()> {
@@ -80,7 +80,7 @@ impl ResourcesByName {
 /// A wrapper around a dictionary that has a Kubernetes Kind (e.g. `Pod`)
 /// as key, and a ResourcesByName as value
 #[derive(Serialize, Default)]
-pub(crate) struct ResourcesByKind(HashMap<String, ResourcesByName>);
+pub(crate) struct ResourcesByKind(BTreeMap<String, ResourcesByName>);
 
 impl ResourcesByKind {
     fn register(
@@ -98,7 +98,7 @@ impl ResourcesByKind {
 /// A wrapper around a dictionary that has a Kubernetes GroupVersion (e.g. `apps/v1`)
 /// as key, and a ResourcesByKind as value
 #[derive(Serialize, Default)]
-pub(crate) struct ResourcesByGroupVersion(HashMap<String, ResourcesByKind>);
+pub(crate) struct ResourcesByGroupVersion(BTreeMap<String, ResourcesByKind>);
 
 impl ResourcesByGroupVersion {
     fn register(
@@ -117,7 +117,7 @@ impl ResourcesByGroupVersion {
 /// the name of a Kubernetes Namespace (e.g. `kube-system`) as key,
 /// and a ResourcesByGroupVersion as value
 #[derive(Serialize, Default)]
-pub(crate) struct ResourcesByNamespace(HashMap<String, ResourcesByGroupVersion>);
+pub(crate) struct ResourcesByNamespace(BTreeMap<String, ResourcesByGroupVersion>);
 
 impl ResourcesByNamespace {
     fn register(
@@ -148,7 +148,7 @@ impl GatekeeperInventory {
     /// Creates a GatekeeperInventory by querying a Kubernetes cluster
     /// for all the resources specified
     pub(crate) fn new(
-        kube_resources: &HashMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>>,
+        kube_resources: &BTreeMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>>,
     ) -> Result<Self> {
         let mut inventory = GatekeeperInventory::default();
 
@@ -190,10 +190,10 @@ mod tests {
 
     #[test]
     fn create() {
-        let mut kube_resources: HashMap<
+        let mut kube_resources: BTreeMap<
             ContextAwareResource,
             ObjectList<kube::core::DynamicObject>,
-        > = HashMap::new();
+        > = BTreeMap::new();
 
         let services = [
             dynamic_object_from_fixture("services", Some("kube-system"), "kube-dns").unwrap(),

--- a/src/runtimes/rego/opa_inventory.rs
+++ b/src/runtimes/rego/opa_inventory.rs
@@ -68,12 +68,12 @@ use crate::policy_metadata::ContextAwareResource;
 use anyhow::{anyhow, Result};
 use kube::api::ObjectList;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// A wrapper around a dictionary that has the resource Name as key,
 /// and a DynamicObject as value
 #[derive(Serialize, Default)]
-pub(crate) struct ResourcesByName(HashMap<String, kube::core::DynamicObject>);
+pub(crate) struct ResourcesByName(BTreeMap<String, kube::core::DynamicObject>);
 
 impl ResourcesByName {
     fn register(&mut self, obj: &kube::core::DynamicObject) -> Result<()> {
@@ -90,7 +90,7 @@ impl ResourcesByName {
 /// A wrapper around a dictionary that has the name of the namespace as key and the list of
 /// ResourcesByName as value
 #[derive(Serialize, Default)]
-pub(crate) struct ResourcesByNamespace(HashMap<String, ResourcesByName>);
+pub(crate) struct ResourcesByNamespace(BTreeMap<String, ResourcesByName>);
 
 impl ResourcesByNamespace {
     fn register(&mut self, obj: &kube::core::DynamicObject) -> Result<()> {
@@ -123,7 +123,7 @@ impl ResourcesByScope {
 /// the plural name of a Kubernetes resource (e.g. `services`) as key,
 /// and a ResourcesByScope as value
 #[derive(Serialize, Default)]
-pub(crate) struct ResourcesByPluralName(HashMap<String, ResourcesByScope>);
+pub(crate) struct ResourcesByPluralName(BTreeMap<String, ResourcesByScope>);
 
 impl ResourcesByPluralName {
     fn register(&mut self, obj: &kube::core::DynamicObject, plural_name: &str) -> Result<()> {
@@ -166,8 +166,8 @@ impl OpaInventory {
     /// Creates a GatekeeperInventory by querying a Kubernetes cluster
     /// for all the resources specified
     pub(crate) fn new(
-        kube_resources: &HashMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>>,
-        plural_names: &HashMap<ContextAwareResource, String>,
+        kube_resources: &BTreeMap<ContextAwareResource, ObjectList<kube::core::DynamicObject>>,
+        plural_names: &BTreeMap<ContextAwareResource, String>,
     ) -> Result<Self> {
         let mut inventory = OpaInventory::default();
 
@@ -200,11 +200,11 @@ mod tests {
 
     #[test]
     fn create() {
-        let mut kube_resources: HashMap<
+        let mut kube_resources: BTreeMap<
             ContextAwareResource,
             ObjectList<kube::core::DynamicObject>,
-        > = HashMap::new();
-        let mut plural_names: HashMap<ContextAwareResource, String> = HashMap::new();
+        > = BTreeMap::new();
+        let mut plural_names: BTreeMap<ContextAwareResource, String> = BTreeMap::new();
 
         let services = [
             dynamic_object_from_fixture("services", Some("kube-system"), "kube-dns").unwrap(),

--- a/src/runtimes/rego/stack.rs
+++ b/src/runtimes/rego/stack.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use anyhow::{anyhow, Result};
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use tokio::sync::mpsc;
 
 pub(crate) struct BurregoStack {
@@ -20,7 +20,7 @@ impl BurregoStack {
     pub fn build_kubernetes_context(
         &self,
         callback_channel: Option<&mpsc::Sender<CallbackRequest>>,
-        ctx_aware_resources_allow_list: &HashSet<ContextAwareResource>,
+        ctx_aware_resources_allow_list: &BTreeSet<ContextAwareResource>,
     ) -> Result<context_aware::KubernetesContext> {
         if ctx_aware_resources_allow_list.is_empty() {
             return Ok(context_aware::KubernetesContext::Empty);


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
refactor: Make Rego inventories ordered with BTreeMap. This increases single access complexity, but we normally read all values.

This is to be consumed by kwctl for deterministic Rego context-aware inventories.



<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
