### PR TITLE
feat: introduce `PolicyEvaluatorPre`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,12 +46,16 @@ tracing = "0.1"
 tracing-futures = "0.2"
 url = { version = "2.2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
-wapc = "1.1"
+#wapc = "1.1"
+wapc = { git = "https://github.com/flavio/wapc-rs/", branch = "expose-wasmtime-provider-pre" }
 wasi-cap-std-sync = { workspace = true }
 wasi-common = { workspace = true }
 wasmparser = "0.118"
 wasmtime = { workspace = true }
-wasmtime-provider = { version = "1.12", features = ["cache"] }
+#wasmtime-provider = { version = "1.12", features = ["cache"] }
+wasmtime-provider = { git = "https://github.com/flavio/wapc-rs/", branch = "expose-wasmtime-provider-pre", features = [
+  "cache",
+] }
 wasmtime-wasi = { workspace = true }
 
 [workspace.dependencies]

--- a/crates/burrego/Cargo.toml
+++ b/crates/burrego/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.21.5"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 chrono-tz = "0.8.4"
 gtmpl = "0.7.1"
 gtmpl_value = "0.5.1"
@@ -22,11 +22,11 @@ serde_json = "1.0.108"
 serde_yaml = "0.9.27"
 thiserror = "1.0"
 tracing = "0.1"
-tracing-subscriber = { version= "0.3", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 url = "2.2.2"
 wasmtime = { workspace = true }
 
 [dev-dependencies]
 anyhow = "1.0"
 assert-json-diff = "2.0.2"
-clap = { version = "4.0", features = [ "derive" ] }
+clap = { version = "4.0", features = ["derive"] }

--- a/src/evaluation_context.rs
+++ b/src/evaluation_context.rs
@@ -36,18 +36,6 @@ impl EvaluationContext {
         self.ctx_aware_resources_allow_list
             .contains(&wanted_resource)
     }
-
-    /// Copy data from another `EvaluationContext` instance
-    pub(crate) fn copy_from(&mut self, other: &EvaluationContext) {
-        if self.policy_id == other.policy_id {
-            // The current evaluation context is about the very same policy
-            // There's nothing to be done
-            return;
-        }
-        self.policy_id = other.policy_id.clone();
-        self.callback_channel = other.callback_channel.clone();
-        self.ctx_aware_resources_allow_list = other.ctx_aware_resources_allow_list.clone();
-    }
 }
 
 impl fmt::Debug for EvaluationContext {

--- a/src/policy_evaluator/policy_evaluator_pre.rs
+++ b/src/policy_evaluator/policy_evaluator_pre.rs
@@ -1,0 +1,71 @@
+use anyhow::Result;
+
+use crate::evaluation_context::EvaluationContext;
+use crate::policy_evaluator::PolicyEvaluator;
+use crate::runtimes::{rego, wapc, wasi_cli, Runtime};
+
+/// Holds pre-initialized stacks for all the types of policies we run
+///
+/// Pre-initialized instances are key to reduce the evaluation time when
+/// using on-demand PolicyEvaluator instances; where on-demand means that
+/// each validation request has a brand new PolicyEvaluator that is discarded
+/// once  the evaluation is done.
+pub(crate) enum StackPre {
+    Wapc(crate::runtimes::wapc::StackPre),
+    Wasi(crate::runtimes::wasi_cli::StackPre),
+    Rego(crate::runtimes::rego::StackPre),
+}
+
+impl From<wapc::StackPre> for StackPre {
+    fn from(wapc_stack_pre: wapc::StackPre) -> Self {
+        StackPre::Wapc(wapc_stack_pre)
+    }
+}
+
+impl From<wasi_cli::StackPre> for StackPre {
+    fn from(wasi_stack_pre: wasi_cli::StackPre) -> Self {
+        StackPre::Wasi(wasi_stack_pre)
+    }
+}
+
+impl From<rego::StackPre> for StackPre {
+    fn from(rego_stack_pre: rego::StackPre) -> Self {
+        StackPre::Rego(rego_stack_pre)
+    }
+}
+
+/// This struct provides a way to quickly allocate a `PolicyEvaluator`
+/// object.
+///
+/// See the [`rehydrate`](PolicyEvaluatorPre::rehydrate) method.
+pub struct PolicyEvaluatorPre {
+    pub(crate) stack_pre: StackPre,
+}
+
+impl PolicyEvaluatorPre {
+    /// Create a `PolicyEvaluator` instance. The creation of the instance is achieved by
+    /// using wasmtime low level primitives (like `wasmtime::InstancePre`) to make the operation
+    /// as fast as possible.
+    ///
+    /// Warning: the Rego stack cannot make use of these low level primitives, but its
+    /// instantiation times are negligible. More details inside of the
+    /// documentation of [`rego::StackPre`](crate::rego::stack_pre::StackPre).
+    pub fn rehydrate(&self, eval_ctx: &EvaluationContext) -> Result<PolicyEvaluator> {
+        let runtime = match &self.stack_pre {
+            StackPre::Wapc(stack_pre) => {
+                let wapc_stack = wapc::WapcStack::new_from_pre(stack_pre, eval_ctx)?;
+                Runtime::Wapc(wapc_stack)
+            }
+            StackPre::Wasi(stack_pre) => {
+                let wasi_stack = wasi_cli::Stack::new_from_pre(stack_pre);
+                Runtime::Cli(wasi_stack)
+            }
+            StackPre::Rego(stack_pre) => {
+                let rego_stack = rego::Stack::new_from_pre(stack_pre)?;
+                Runtime::Rego(rego_stack)
+            }
+        };
+
+        Ok(PolicyEvaluator::new(runtime))
+    }
+}

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -8,7 +8,7 @@ pub(crate) mod wasi_cli;
 
 pub(crate) enum Runtime {
     Wapc(wapc::WapcStack),
-    Burrego(rego::BurregoStack),
+    Rego(rego::Stack),
     Cli(wasi_cli::Stack),
 }
 
@@ -17,7 +17,7 @@ impl Display for Runtime {
         match self {
             Runtime::Cli(_) => write!(f, "wasi"),
             Runtime::Wapc(_) => write!(f, "wapc"),
-            Runtime::Burrego(stack) => match stack.policy_execution_mode {
+            Runtime::Rego(stack) => match stack.policy_execution_mode {
                 RegoPolicyExecutionMode::Opa => {
                     write!(f, "OPA")
                 }

--- a/src/runtimes/rego/errors.rs
+++ b/src/runtimes/rego/errors.rs
@@ -48,4 +48,7 @@ pub enum RegoRuntimeError {
 
     #[error("invalid response from policy: {0}")]
     InvalidResponseWithError(#[source] serde_json::Error),
+
+    #[error("cannot allocate Rego evaluator: {0}")]
+    EvaluatorError(String),
 }

--- a/src/runtimes/rego/mod.rs
+++ b/src/runtimes/rego/mod.rs
@@ -4,10 +4,12 @@ mod gatekeeper_inventory;
 mod opa_inventory;
 mod runtime;
 mod stack;
+mod stack_pre;
 
 use burrego::host_callbacks::HostCallbacks;
 pub(crate) use runtime::Runtime;
-pub(crate) use stack::BurregoStack;
+pub(crate) use stack::Stack;
+pub(crate) use stack_pre::StackPre;
 
 #[tracing::instrument(level = "error")]
 fn opa_abort(msg: &str) {}

--- a/src/runtimes/rego/runtime.rs
+++ b/src/runtimes/rego/runtime.rs
@@ -7,10 +7,10 @@ use crate::admission_response::{AdmissionResponse, AdmissionResponseStatus};
 use crate::policy_evaluator::RegoPolicyExecutionMode;
 use crate::policy_evaluator::{PolicySettings, ValidateRequest};
 use crate::runtimes::rego::{
-    context_aware, context_aware::KubernetesContext, errors::RegoRuntimeError, BurregoStack,
+    context_aware, context_aware::KubernetesContext, errors::RegoRuntimeError, Stack,
 };
 
-pub(crate) struct Runtime<'a>(pub(crate) &'a mut BurregoStack);
+pub(crate) struct Runtime<'a>(pub(crate) &'a mut Stack);
 
 impl<'a> Runtime<'a> {
     pub fn validate(

--- a/src/runtimes/rego/stack.rs
+++ b/src/runtimes/rego/stack.rs
@@ -4,7 +4,6 @@ use tokio::sync::mpsc;
 use crate::{
     callback_requests::CallbackRequest,
     policy_evaluator::RegoPolicyExecutionMode,
-    policy_evaluator_builder::EpochDeadlines,
     policy_metadata::ContextAwareResource,
     runtimes::rego::{
         context_aware,
@@ -22,23 +21,6 @@ pub(crate) struct Stack {
 }
 
 impl Stack {
-    pub(crate) fn new(
-        engine: wasmtime::Engine,
-        module: wasmtime::Module,
-        epoch_deadlines: Option<EpochDeadlines>,
-        entrypoint_id: i32,
-        policy_execution_mode: RegoPolicyExecutionMode,
-    ) -> Result<Self> {
-        let stack_pre = StackPre::new(
-            engine,
-            module,
-            epoch_deadlines,
-            entrypoint_id,
-            policy_execution_mode,
-        );
-        Self::new_from_pre(&stack_pre)
-    }
-
     /// Create a new `Stack` using a `StackPre` object
     pub fn new_from_pre(stack_pre: &StackPre) -> Result<Self> {
         let evaluator = stack_pre

--- a/src/runtimes/rego/stack_pre.rs
+++ b/src/runtimes/rego/stack_pre.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+
+use crate::policy_evaluator::RegoPolicyExecutionMode;
+use crate::policy_evaluator_builder::EpochDeadlines;
+
+/// This struct allows to follow the `StackPre -> Stack`
+/// "pattern" also for Rego policies.
+///
+/// However, Rego policies cannot make use of `wasmtime::InstancePre`
+/// to reduce the instantiation times. That happens because all
+/// Rego WebAssembly policies import their Wasm Memory from the host.
+/// The Wasm Memory is defined inside of a `wasmtime::Store`, which is
+/// something that `wasmtime::InstnacePre` objects do not have (rightfully!).
+///
+/// However, Rego Wasm modules are so small thta instantiating them from scratch
+/// is already a cheap operation.
+#[derive(Clone)]
+pub(crate) struct StackPre {
+    engine: wasmtime::Engine,
+    module: wasmtime::Module,
+    epoch_deadlines: Option<EpochDeadlines>,
+    pub entrypoint_id: i32,
+    pub policy_execution_mode: RegoPolicyExecutionMode,
+}
+
+impl StackPre {
+    pub(crate) fn new(
+        engine: wasmtime::Engine,
+        module: wasmtime::Module,
+        epoch_deadlines: Option<EpochDeadlines>,
+        entrypoint_id: i32,
+        policy_execution_mode: RegoPolicyExecutionMode,
+    ) -> Self {
+        Self {
+            engine,
+            module,
+            epoch_deadlines,
+            entrypoint_id,
+            policy_execution_mode,
+        }
+    }
+
+    /// Create a fresh `burrego::Evaluator`
+    pub(crate) fn rehydrate(&self) -> Result<burrego::Evaluator> {
+        let mut builder = burrego::EvaluatorBuilder::default()
+            .engine(&self.engine)
+            .module(self.module.clone())
+            .host_callbacks(crate::runtimes::rego::new_host_callbacks());
+
+        if let Some(deadlines) = self.epoch_deadlines {
+            builder = builder.enable_epoch_interruptions(deadlines.wapc_func);
+        }
+        let evaluator = builder.build()?;
+        Ok(evaluator)
+    }
+}

--- a/src/runtimes/wapc/mod.rs
+++ b/src/runtimes/wapc/mod.rs
@@ -1,6 +1,8 @@
 mod callback;
 mod runtime;
 mod stack;
+mod stack_pre;
 
 pub(crate) use runtime::Runtime;
 pub(crate) use stack::WapcStack;
+pub(crate) use stack_pre::StackPre;

--- a/src/runtimes/wapc/runtime.rs
+++ b/src/runtimes/wapc/runtime.rs
@@ -168,7 +168,7 @@ mod tests {
         evaluation_context::EvaluationContext, runtimes::wapc::callback::new_host_callback,
     };
     use std::{
-        sync::{self, Arc, Mutex},
+        sync::{self, Arc},
         thread, time,
     };
 
@@ -206,7 +206,7 @@ mod tests {
             ctx_aware_resources_allow_list: Default::default(),
         };
 
-        let eval_ctx = Arc::new(Mutex::new(eval_ctx));
+        let eval_ctx = Arc::new(eval_ctx);
 
         let wapc_engine = wapc_engine_builder
             .build()

--- a/src/runtimes/wapc/stack.rs
+++ b/src/runtimes/wapc/stack.rs
@@ -1,9 +1,7 @@
 use anyhow::Result;
 use std::sync::Arc;
-use wasmtime_provider::wasmtime;
 
 use crate::evaluation_context::EvaluationContext;
-use crate::policy_evaluator_builder::EpochDeadlines;
 use crate::runtimes::wapc::callback::new_host_callback;
 
 use super::StackPre;
@@ -15,24 +13,6 @@ pub(crate) struct WapcStack {
 }
 
 impl WapcStack {
-    pub(crate) fn new(
-        engine: wasmtime::Engine,
-        module: wasmtime::Module,
-        epoch_deadlines: Option<EpochDeadlines>,
-        eval_ctx: EvaluationContext,
-    ) -> Result<Self> {
-        let eval_ctx = Arc::new(eval_ctx);
-
-        let stack_pre = StackPre::new(engine, module, epoch_deadlines)?;
-        let wapc_host = Self::wapc_host_from_pre(&stack_pre, eval_ctx.clone())?;
-
-        Ok(Self {
-            wapc_host,
-            stack_pre,
-            eval_ctx,
-        })
-    }
-
     pub(crate) fn new_from_pre(stack_pre: &StackPre, eval_ctx: &EvaluationContext) -> Result<Self> {
         let eval_ctx = Arc::new(eval_ctx.to_owned());
         let wapc_host = Self::wapc_host_from_pre(stack_pre, eval_ctx.clone())?;

--- a/src/runtimes/wapc/stack_pre.rs
+++ b/src/runtimes/wapc/stack_pre.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+use wasmtime_provider::wasmtime;
+
+use crate::policy_evaluator_builder::EpochDeadlines;
+
+/// Reduce allocation time of new `WasmtimeProviderEngine`, see the `rehydrate` method
+#[derive(Clone)]
+pub(crate) struct StackPre {
+    engine_provider_pre: wasmtime_provider::WasmtimeEngineProviderPre,
+}
+
+impl StackPre {
+    pub(crate) fn new(
+        engine: wasmtime::Engine,
+        module: wasmtime::Module,
+        epoch_deadlines: Option<EpochDeadlines>,
+    ) -> Result<Self> {
+        let mut builder = wasmtime_provider::WasmtimeEngineProviderBuilder::new()
+            .engine(engine)
+            .module(module);
+        if let Some(deadlines) = epoch_deadlines {
+            builder = builder.enable_epoch_interruptions(deadlines.wapc_init, deadlines.wapc_func);
+        }
+
+        let engine_provider_pre = builder.build_pre()?;
+        Ok(Self {
+            engine_provider_pre,
+        })
+    }
+
+    /// Allocate a new `WasmtimeEngineProvider` instance by using a pre-allocated instance
+    pub(crate) fn rehydrate(&self) -> Result<wasmtime_provider::WasmtimeEngineProvider> {
+        let engine = self.engine_provider_pre.rehydrate()?;
+        Ok(engine)
+    }
+}

--- a/src/runtimes/wasi_cli/mod.rs
+++ b/src/runtimes/wasi_cli/mod.rs
@@ -1,6 +1,8 @@
 mod errors;
 mod runtime;
 mod stack;
+mod stack_pre;
 
 pub(crate) use runtime::Runtime;
 pub(crate) use stack::Stack;
+pub(crate) use stack_pre::StackPre;

--- a/src/runtimes/wasi_cli/stack.rs
+++ b/src/runtimes/wasi_cli/stack.rs
@@ -1,11 +1,8 @@
-use anyhow::Result;
 use std::io::Cursor;
 use wasi_common::pipe::{ReadPipe, WritePipe};
 use wasi_common::WasiCtx;
-use wasmtime::{Engine, Module};
 use wasmtime_wasi::sync::WasiCtxBuilder;
 
-use crate::policy_evaluator_builder::EpochDeadlines;
 use crate::runtimes::wasi_cli::{errors::WasiRuntimeError, stack_pre::StackPre};
 
 const EXIT_SUCCESS: i32 = 0;
@@ -24,15 +21,6 @@ pub(crate) struct RunResult {
 }
 
 impl Stack {
-    pub(crate) fn new(
-        engine: Engine,
-        module: Module,
-        epoch_deadlines: Option<EpochDeadlines>,
-    ) -> Result<Self> {
-        let stack_pre = StackPre::new(engine, module, epoch_deadlines)?;
-        Ok(Self { stack_pre })
-    }
-
     pub(crate) fn new_from_pre(stack_pre: &StackPre) -> Self {
         Self {
             stack_pre: stack_pre.to_owned(),

--- a/src/runtimes/wasi_cli/stack.rs
+++ b/src/runtimes/wasi_cli/stack.rs
@@ -1,17 +1,26 @@
 use anyhow::Result;
+use std::io::Cursor;
+use wasi_common::pipe::{ReadPipe, WritePipe};
 use wasi_common::WasiCtx;
-use wasmtime::{Engine, InstancePre, Linker, Module};
+use wasmtime::{Engine, Module};
+use wasmtime_wasi::sync::WasiCtxBuilder;
 
 use crate::policy_evaluator_builder::EpochDeadlines;
+use crate::runtimes::wasi_cli::{errors::WasiRuntimeError, stack_pre::StackPre};
+
+const EXIT_SUCCESS: i32 = 0;
 
 pub(crate) struct Context {
     pub(crate) wasi_ctx: WasiCtx,
 }
 
 pub(crate) struct Stack {
-    pub(crate) engine: Engine,
-    pub(crate) epoch_deadlines: Option<EpochDeadlines>,
-    pub(crate) instance_pre: InstancePre<Context>,
+    stack_pre: StackPre,
+}
+
+pub(crate) struct RunResult {
+    pub stdout: String,
+    pub stderr: String,
 }
 
 impl Stack {
@@ -20,15 +29,92 @@ impl Stack {
         module: Module,
         epoch_deadlines: Option<EpochDeadlines>,
     ) -> Result<Self> {
-        let mut linker = Linker::<Context>::new(&engine);
-        wasmtime_wasi::add_to_linker(&mut linker, |c: &mut Context| &mut c.wasi_ctx)?;
+        let stack_pre = StackPre::new(engine, module, epoch_deadlines)?;
+        Ok(Self { stack_pre })
+    }
 
-        let instance_pre = linker.instantiate_pre(&module)?;
+    pub(crate) fn new_from_pre(stack_pre: &StackPre) -> Self {
+        Self {
+            stack_pre: stack_pre.to_owned(),
+        }
+    }
 
-        Ok(Stack {
-            engine,
-            instance_pre,
-            epoch_deadlines,
-        })
+    /// Run a WASI program with the given input and args
+    pub(crate) fn run(
+        &self,
+        input: &[u8],
+        args: &[&str],
+    ) -> std::result::Result<RunResult, WasiRuntimeError> {
+        let stdout_pipe = WritePipe::new_in_memory();
+        let stderr_pipe = WritePipe::new_in_memory();
+        let stdin_pipe = ReadPipe::new(Cursor::new(input.to_owned()));
+
+        let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+
+        let wasi_ctx = WasiCtxBuilder::new()
+            .args(&args)?
+            .stdin(Box::new(stdin_pipe))
+            .stdout(Box::new(stdout_pipe.clone()))
+            .stderr(Box::new(stderr_pipe.clone()))
+            .build();
+        let ctx = Context { wasi_ctx };
+
+        let mut store = self.stack_pre.build_store(ctx);
+        let instance = self
+            .stack_pre
+            .rehydrate(&mut store)
+            .map_err(WasiRuntimeError::WasmInstantiate)?;
+        let start_fn = instance
+            .get_typed_func::<(), ()>(&mut store, "_start")
+            .map_err(WasiRuntimeError::WasmMissingStartFn)?;
+        let evaluation_result = start_fn.call(&mut store, ());
+
+        // Dropping the store, this is no longer needed, plus it's keeping
+        // references to the WritePipe(s) that we need exclusive access to.
+        drop(store);
+
+        let stderr = pipe_to_string("stderr", stderr_pipe)?;
+
+        if let Err(err) = evaluation_result {
+            if let Some(exit_error) = err.downcast_ref::<wasmtime_wasi::I32Exit>() {
+                if exit_error.0 == EXIT_SUCCESS {
+                    let stdout = pipe_to_string("stdout", stdout_pipe)?;
+                    return Ok(RunResult { stdout, stderr });
+                } else {
+                    return Err(WasiRuntimeError::WasiEvaluation {
+                        code: Some(exit_error.0),
+                        stderr,
+                        error: err,
+                    });
+                }
+            }
+            return Err(WasiRuntimeError::WasiEvaluation {
+                code: None,
+                stderr,
+                error: err,
+            });
+        }
+
+        let stdout = pipe_to_string("stdout", stdout_pipe)?;
+        Ok(RunResult { stdout, stderr })
+    }
+}
+
+fn pipe_to_string(
+    name: &str,
+    pipe: WritePipe<Cursor<Vec<u8>>>,
+) -> std::result::Result<String, WasiRuntimeError> {
+    match pipe.try_into_inner() {
+        Ok(cursor) => {
+            let buf = cursor.into_inner();
+            String::from_utf8(buf).map_err(|e| WasiRuntimeError::PipeConversion {
+                name: name.to_string(),
+                error: format!("Cannot convert buffer to UTF8 string: {e}"),
+            })
+        }
+        Err(_) => Err(WasiRuntimeError::PipeConversion {
+            name: name.to_string(),
+            error: "cannot convert pipe into inner".to_string(),
+        }),
     }
 }

--- a/src/runtimes/wasi_cli/stack_pre.rs
+++ b/src/runtimes/wasi_cli/stack_pre.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+
+use crate::policy_evaluator_builder::EpochDeadlines;
+use crate::runtimes::wasi_cli::stack::Context;
+
+/// Reduce the allocation time of a Wasi Stack. This is done by leveraging `wasmtime::InstancePre`.
+#[derive(Clone)]
+pub(crate) struct StackPre {
+    engine: wasmtime::Engine,
+    instance_pre: wasmtime::InstancePre<Context>,
+    epoch_deadlines: Option<EpochDeadlines>,
+}
+
+impl StackPre {
+    pub(crate) fn new(
+        engine: wasmtime::Engine,
+        module: wasmtime::Module,
+        epoch_deadlines: Option<EpochDeadlines>,
+    ) -> Result<Self> {
+        let mut linker = wasmtime::Linker::<Context>::new(&engine);
+        wasmtime_wasi::add_to_linker(&mut linker, |c: &mut Context| &mut c.wasi_ctx)?;
+
+        let instance_pre = linker.instantiate_pre(&module)?;
+        Ok(Self {
+            engine,
+            instance_pre,
+            epoch_deadlines,
+        })
+    }
+
+    /// Create a brand new `wasmtime::Store` to be used during an evaluation
+    pub(crate) fn build_store(&self, ctx: Context) -> wasmtime::Store<Context> {
+        let mut store = wasmtime::Store::new(&self.engine, ctx);
+        if let Some(deadline) = self.epoch_deadlines {
+            store.set_epoch_deadline(deadline.wapc_func);
+        }
+
+        store
+    }
+
+    /// Allocate a new `wasmtime::Instance` that is bound to the given `wasmtime::Store`.
+    /// It's recommended to provide a brand new `wasmtime::Store` created by the
+    /// `build_store` method
+    pub(crate) fn rehydrate(
+        &self,
+        store: &mut wasmtime::Store<Context>,
+    ) -> Result<wasmtime::Instance> {
+        self.instance_pre.instantiate(store)
+    }
+}


### PR DESCRIPTION
Introduce pre-initialized stack for all the types of policies that we currently support (Rego, waPC and WASI). These pre-initialized instance are managed by a high level resource called `PolicyEvaluatorPre`.

`PolicyEvaluatorPre` is created by `PolicyEvaluatorBuilder` once, then it can be used to create as many `PolicyEvaluator` instances as needed.

The `PolicyEvaluatorPre` instance is an immutable structure that can be safely shared across different threads once wrapped into a `Arc`.

This change is required to further reduce the memory usage of Policy Server, without compromising our performance.

Note: this PR is currently consuming a fork of waPC. I'm waiting for upstream to merge my PR.
