### PR TITLE
refactor: change signature of `PolicyEvaluator.validate`

### DIFF
--- a/src/policy_evaluator/policy_evaluator_pre.rs
+++ b/src/policy_evaluator/policy_evaluator_pre.rs
@@ -66,6 +66,6 @@ impl PolicyEvaluatorPre {
             }
         };
 
-        Ok(PolicyEvaluator::new(runtime))
+        Ok(PolicyEvaluator::new(runtime, eval_ctx))
     }
 }


### PR DESCRIPTION
Remove the requirement to provide `EvaluationContext` when invoking the `validate` method.

This is no longer required because now the only way to create a `PolicyEvaluator` is by using `PolicyEvaluatorPre.rehydrate`, which already takes a `EvaluationContext` as parameter.
