### PR TITLE
unblock kwctl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.13.2"
+version = "0.13.3"
 
 [workspace]
 members = ["crates/burrego"]

--- a/src/evaluation_context.rs
+++ b/src/evaluation_context.rs
@@ -7,7 +7,7 @@ use crate::policy_metadata::ContextAwareResource;
 
 /// A struct that holds metadata and other data that are needed when a policy
 /// is being evaluated
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct EvaluationContext {
     /// The policy identifier. This is mostly relevant for Policy Server,
     /// which uses the identifier provided by the user inside of the `policy.yml`


### PR DESCRIPTION
These changes are required by kwctl to consume latest version of policy-evaluator

- EvaluationContext: derive `Default` trait
- Patch bump: 0.13.3
