### PR TITLE
refactor: Partially drop anyhow from `crate::runtimes:wapc`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,3 +29,12 @@ pub enum ArtifactHubError {
     #[error("annotation \"{0}\" in policy metadata is malformed, must be a string \"true\" or \"false\"")]
     MalformedBoolString(String),
 }
+
+#[derive(Error, Debug)]
+pub enum PolicyEvaluatorError {
+    #[error("protocol_version is only applicable to a Kubewarden policy")]
+    InvalidProtocolVersion(),
+
+    #[error("protocol_version is only applicable to a Kubewarden policy")]
+    InvokeWapcProtocolVersion(#[source] crate::runtimes::wapc::errors::WapcRuntimeError),
+}

--- a/src/policy_evaluator/evaluator.rs
+++ b/src/policy_evaluator/evaluator.rs
@@ -77,7 +77,7 @@ impl PolicyEvaluator {
 
     pub fn protocol_version(&mut self) -> Result<ProtocolVersion> {
         match &mut self.runtime {
-            Runtime::Wapc(ref mut wapc_stack) => WapcRuntime(wapc_stack).protocol_version(),
+            Runtime::Wapc(ref mut wapc_stack) => Ok(WapcRuntime(wapc_stack).protocol_version()?),
             _ => Err(anyhow!(
                 "protocol_version is only applicable to a Kubewarden policy"
             )),

--- a/src/runtimes/rego/errors.rs
+++ b/src/runtimes/rego/errors.rs
@@ -51,4 +51,7 @@ pub enum RegoRuntimeError {
 
     #[error("cannot allocate Rego evaluator: {0}")]
     EvaluatorError(String),
+
+    #[error("cannot build Rego engine: {0}")]
+    RegoEngineBuilder(#[source] burrego::errors::BurregoError),
 }

--- a/src/runtimes/rego/stack_pre.rs
+++ b/src/runtimes/rego/stack_pre.rs
@@ -1,7 +1,6 @@
-use anyhow::Result;
-
 use crate::policy_evaluator::RegoPolicyExecutionMode;
 use crate::policy_evaluator_builder::EpochDeadlines;
+use crate::runtimes::rego::errors::{RegoRuntimeError, Result};
 
 /// This struct allows to follow the `StackPre -> Stack`
 /// "pattern" also for Rego policies.
@@ -50,7 +49,9 @@ impl StackPre {
         if let Some(deadlines) = self.epoch_deadlines {
             builder = builder.enable_epoch_interruptions(deadlines.wapc_func);
         }
-        let evaluator = builder.build()?;
+        let evaluator = builder
+            .build()
+            .map_err(RegoRuntimeError::RegoEngineBuilder)?;
         Ok(evaluator)
     }
 }

--- a/src/runtimes/wapc/errors.rs
+++ b/src/runtimes/wapc/errors.rs
@@ -11,6 +11,13 @@ pub enum WapcRuntimeError {
     #[error("invalid response from policy: {0}")]
     InvalidResponseWithError(#[source] serde_json::Error),
 
+    #[error("cannot create ProtocolVersion object from {res:?}: {error}")]
+    CreateProtocolVersion {
+        res: std::vec::Vec<u8>,
+        #[source]
+        error: wasmtime::Error,
+    },
+
     #[error("cannot invoke 'protocol_version' waPC function : {0}")]
     InvokeProtocolVersion(#[source] wapc::errors::Error),
 }

--- a/src/runtimes/wapc/errors.rs
+++ b/src/runtimes/wapc/errors.rs
@@ -2,7 +2,6 @@ use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, WapcRuntimeError>;
 
-
 #[derive(Error, Debug)]
 pub enum WapcRuntimeError {
     #[error("invalid response format: {0}")]
@@ -20,4 +19,10 @@ pub enum WapcRuntimeError {
 
     #[error("cannot invoke 'protocol_version' waPC function : {0}")]
     InvokeProtocolVersion(#[source] wapc::errors::Error),
+
+    #[error("cannot build Wasmtime engine: {0}")]
+    WasmtimeEngineBuilder(#[source] wasmtime_provider::errors::Error),
+
+    #[error("cannot build Wapc host: {0}")]
+    WapcHostBuilder(#[source] wapc::errors::Error),
 }

--- a/src/runtimes/wapc/errors.rs
+++ b/src/runtimes/wapc/errors.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, WapcRuntimeError>;
+
+
+#[derive(Error, Debug)]
+pub enum WapcRuntimeError {
+    #[error("invalid response format: {0}")]
+    InvalidResponseFormat(#[source] anyhow::Error),
+
+    #[error("invalid response from policy: {0}")]
+    InvalidResponseWithError(#[source] serde_json::Error),
+
+    #[error("cannot invoke 'protocol_version' waPC function : {0}")]
+    InvokeProtocolVersion(#[source] wapc::errors::Error),
+}

--- a/src/runtimes/wapc/mod.rs
+++ b/src/runtimes/wapc/mod.rs
@@ -1,4 +1,5 @@
 mod callback;
+mod errors;
 mod runtime;
 mod stack;
 mod stack_pre;

--- a/src/runtimes/wapc/mod.rs
+++ b/src/runtimes/wapc/mod.rs
@@ -1,5 +1,5 @@
 mod callback;
-mod errors;
+pub mod errors;
 mod runtime;
 mod stack;
 mod stack_pre;

--- a/src/runtimes/wapc/stack.rs
+++ b/src/runtimes/wapc/stack.rs
@@ -1,8 +1,10 @@
-use anyhow::Result;
 use std::sync::Arc;
 
 use crate::evaluation_context::EvaluationContext;
-use crate::runtimes::wapc::callback::new_host_callback;
+use crate::runtimes::wapc::{
+    callback::new_host_callback,
+    errors::{Result, WapcRuntimeError},
+};
 
 use super::StackPre;
 
@@ -56,7 +58,8 @@ impl WapcStack {
     ) -> Result<wapc::WapcHost> {
         let engine_provider = pre.rehydrate()?;
         let wapc_host =
-            wapc::WapcHost::new(Box::new(engine_provider), Some(new_host_callback(eval_ctx)))?;
+            wapc::WapcHost::new(Box::new(engine_provider), Some(new_host_callback(eval_ctx)))
+                .map_err(WapcRuntimeError::WapcHostBuilder)?;
         Ok(wapc_host)
     }
 }

--- a/src/runtimes/wapc/stack_pre.rs
+++ b/src/runtimes/wapc/stack_pre.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
 use wasmtime_provider::wasmtime;
 
 use crate::policy_evaluator_builder::EpochDeadlines;
+use crate::runtimes::wapc::errors::{Result, WapcRuntimeError};
 
 /// Reduce allocation time of new `WasmtimeProviderEngine`, see the `rehydrate` method
 #[derive(Clone)]
@@ -22,7 +22,9 @@ impl StackPre {
             builder = builder.enable_epoch_interruptions(deadlines.wapc_init, deadlines.wapc_func);
         }
 
-        let engine_provider_pre = builder.build_pre()?;
+        let engine_provider_pre = builder
+            .build_pre()
+            .map_err(WapcRuntimeError::WasmtimeEngineBuilder)?;
         Ok(Self {
             engine_provider_pre,
         })
@@ -30,7 +32,10 @@ impl StackPre {
 
     /// Allocate a new `WasmtimeEngineProvider` instance by using a pre-allocated instance
     pub(crate) fn rehydrate(&self) -> Result<wasmtime_provider::WasmtimeEngineProvider> {
-        let engine = self.engine_provider_pre.rehydrate()?;
+        let engine = self
+            .engine_provider_pre
+            .rehydrate()
+            .map_err(WapcRuntimeError::WasmtimeEngineBuilder)?;
         Ok(engine)
     }
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/policy-evaluator/issues/377.

- Partially implement thiserror a type and its enums for `crate::runtimes::wapc`.
  It is still missing `crate::runtimes::wapc::callback` which will follow up later. The definition of the callback function [type is more complicated](https://github.com/kubewarden/policy-evaluator/blob/main/src/runtimes/wapc/callback.rs#L16), and I wanted to have a full codepath for the errors first.
- Finish migration to thiserror for `crate::runtimes::rego`. 

I recommend reviewing per commit, yet note that for `protocol_version()` there's a stopgap change between commits.

Note: `protocol_version()` is only consumed by kwctl but not yet by policy-server, opened https://github.com/kubewarden/policy-server/issues/642.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI, integration tests.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
