### PR TITLE
refactor: Drop anyhow from wasi_cli

### DIFF
--- a/src/runtimes/rego/errors.rs
+++ b/src/runtimes/rego/errors.rs
@@ -5,7 +5,7 @@ pub type Result<T> = std::result::Result<T, RegoRuntimeError>;
 #[derive(Error, Debug)]
 pub enum RegoRuntimeError {
     #[error("cannot build Rego context aware data: callback channel is not set")]
-    CallbackChannelNotSet(),
+    CallbackChannelNotSet,
 
     #[error("cannot convert callback response into a list of kubernetes objects: {0}")]
     CallbackConvertList(#[source] serde_json::Error),
@@ -23,28 +23,28 @@ pub enum RegoRuntimeError {
     CallbackGetPluralName(#[source] serde_json::Error),
 
     #[error("DynamicObject does not have a name")]
-    GatekeeperInventoryMissingName(),
+    GatekeeperInventoryMissingName,
 
     #[error("DynamicObject does not have a namespace")]
-    GatekeeperInventoryMissingNamespace(),
+    GatekeeperInventoryMissingNamespace,
 
     #[error("DynamicObject does not have a name")]
-    OpaInventoryMissingName(),
+    OpaInventoryMissingName,
 
     #[error("DynamicObject does not have a namespace")]
-    OpaInventoryMissingNamespace(),
+    OpaInventoryMissingNamespace,
 
     #[error("trying to add a namespaced resource to a list of clusterwide resources")]
-    OpaInventoryAddNamespacedRes(),
+    OpaInventoryAddNamespacedRes,
 
     #[error("trying to add a clusterwide resource to a list of namespaced resources")]
-    OpaInventoryAddClusterwideRes(),
+    OpaInventoryAddClusterwideRes,
 
     #[error("cannot find plural name for resource {0}")]
     OpaInventoryMissingPluralName(String),
 
     #[error("invalid response from policy")]
-    InvalidResponse(),
+    InvalidResponse,
 
     #[error("invalid response from policy: {0}")]
     InvalidResponseWithError(#[source] serde_json::Error),

--- a/src/runtimes/rego/gatekeeper_inventory.rs
+++ b/src/runtimes/rego/gatekeeper_inventory.rs
@@ -73,7 +73,7 @@ impl ResourcesByName {
             .metadata
             .name
             .clone()
-            .ok_or(RegoRuntimeError::GatekeeperInventoryMissingName())?;
+            .ok_or(RegoRuntimeError::GatekeeperInventoryMissingName)?;
         self.0.insert(name, obj.to_owned());
         Ok(())
     }
@@ -131,7 +131,7 @@ impl ResourcesByNamespace {
             .metadata
             .namespace
             .clone()
-            .ok_or(RegoRuntimeError::GatekeeperInventoryMissingNamespace())?;
+            .ok_or(RegoRuntimeError::GatekeeperInventoryMissingNamespace)?;
         self.0.entry(namespace).or_default().register(obj, resource)
     }
 }

--- a/src/runtimes/rego/opa_inventory.rs
+++ b/src/runtimes/rego/opa_inventory.rs
@@ -82,7 +82,7 @@ impl ResourcesByName {
             .metadata
             .name
             .clone()
-            .ok_or(RegoRuntimeError::OpaInventoryMissingName())?;
+            .ok_or(RegoRuntimeError::OpaInventoryMissingName)?;
         self.0.insert(name, obj.to_owned());
         Ok(())
     }
@@ -99,7 +99,7 @@ impl ResourcesByNamespace {
             .metadata
             .namespace
             .clone()
-            .ok_or(RegoRuntimeError::OpaInventoryMissingNamespace())?;
+            .ok_or(RegoRuntimeError::OpaInventoryMissingNamespace)?;
         self.0.entry(namespace).or_default().register(obj)
     }
 }
@@ -135,12 +135,12 @@ impl ResourcesByPluralName {
                 match resources_by_scope {
                     ResourcesByScope::Cluster(_) => {
                         if obj_namespaced {
-                            return Err(RegoRuntimeError::OpaInventoryAddNamespacedRes());
+                            return Err(RegoRuntimeError::OpaInventoryAddNamespacedRes);
                         }
                     }
                     ResourcesByScope::Namespace(_) => {
                         if !obj_namespaced {
-                            return Err(RegoRuntimeError::OpaInventoryAddClusterwideRes());
+                            return Err(RegoRuntimeError::OpaInventoryAddClusterwideRes);
                         }
                     }
                 }

--- a/src/runtimes/rego/runtime.rs
+++ b/src/runtimes/rego/runtime.rs
@@ -129,7 +129,7 @@ impl<'a> Runtime<'a> {
 
                         let violations: Violations = evaluation_result
                             .get(0)
-                            .ok_or_else(RegoRuntimeError::InvalidResponse)
+                            .ok_or_else(|| RegoRuntimeError::InvalidResponse)
                             .and_then(|response| {
                                 serde_json::from_value(response.clone())
                                     .map_err(RegoRuntimeError::InvalidResponseWithError)

--- a/src/runtimes/rego/stack.rs
+++ b/src/runtimes/rego/stack.rs
@@ -43,7 +43,7 @@ impl Stack {
         }
 
         match callback_channel {
-            None => Err(RegoRuntimeError::CallbackChannelNotSet()),
+            None => Err(RegoRuntimeError::CallbackChannelNotSet),
             Some(chan) => {
                 let cluster_resources =
                     context_aware::get_allowed_resources(chan, ctx_aware_resources_allow_list)?;

--- a/src/runtimes/wasi_cli/errors.rs
+++ b/src/runtimes/wasi_cli/errors.rs
@@ -4,9 +4,6 @@ pub type Result<T> = std::result::Result<T, WasiRuntimeError>;
 
 #[derive(Error, Debug)]
 pub enum WasiRuntimeError {
-    #[error("cannot set wasi args")]
-    WasiStringArray(#[source] wasi_common::StringArrayError),
-
     #[error("program exited with code {code:?}; stderr set to '{stderr}', error: '{error}'")]
     WasiEvaluation {
         code: Option<i32>,
@@ -14,6 +11,9 @@ pub enum WasiRuntimeError {
         #[source]
         error: wasmtime::Error,
     },
+
+    #[error("cannot define host function '{name}': {error}")]
+    WasmHostFuncDefinitionError { name: String, error: String },
 
     #[error("cannot find `_start` function inside of module: {0}")]
     WasmMissingStartFn(#[source] wasmtime::Error),
@@ -47,25 +47,3 @@ pub enum WasiRuntimeError {
     #[error("host_call: cannot get write access to STDIN")]
     WasiWriteAccessStdin(),
 }
-
-impl From<std::convert::Infallible> for WasiRuntimeError {
-    fn from(_: std::convert::Infallible) -> Self {
-        unreachable!()
-    }
-}
-
-// impl From<std::result::Result<std::convert::Infallible, wasmtime::Error>>
-//     for std::result::Result<(), WasiRuntimeError>
-// {
-//     fn from(_: std::convert::Infallible) -> Self {
-//         unreachable!()
-//     }
-// }
-
-// impl Into<std::result::Result<(), WasiRuntimeError>>
-//     for std::result::Result<std::convert::Infallible, wasmtime::Error>
-// {
-//     fn into(_: std::result::Result<(), WasiRuntimeError>) -> Self {
-//         unreachable!()
-//     }
-// }

--- a/src/runtimes/wasi_cli/errors.rs
+++ b/src/runtimes/wasi_cli/errors.rs
@@ -1,23 +1,55 @@
 use thiserror::Error;
 
+pub type Result<T> = std::result::Result<T, WasiRuntimeError>;
+
 #[derive(Error, Debug)]
 pub enum WasiRuntimeError {
     #[error("cannot set wasi args")]
-    WasiStringArray(#[from] wasi_common::StringArrayError),
+    WasiStringArray(#[source] wasi_common::StringArrayError),
 
     #[error("program exited with code {code:?}; stderr set to '{stderr}', error: '{error}'")]
     WasiEvaluation {
         code: Option<i32>,
         stderr: String,
+        #[source]
         error: wasmtime::Error,
     },
 
-    #[error("cannot instantiate module: {0}")]
-    WasmInstantiate(wasmtime::Error),
-
     #[error("cannot find `_start` function inside of module: {0}")]
-    WasmMissingStartFn(wasmtime::Error),
+    WasmMissingStartFn(#[source] wasmtime::Error),
 
     #[error("{name} pipe conversion error: {error}")]
     PipeConversion { name: String, error: String },
+
+    #[error("cannot instantiate module: {0}")]
+    WasmLinkerError(#[source] wasmtime::Error),
+
+    #[error("cannot add to linker: {0}")]
+    WasmInstantiate(#[source] wasmtime::Error),
+
+    #[error("cannot find 'mem' export")]
+    WasiMemExport(),
+
+    #[error("'mem' export cannot be converted into a Memory instance")]
+    WasiMemExportCannotConvert(),
+
+    #[error("cannot build WasiCtxBuilder: {0}")]
+    WasiCtxBuilder(#[source] wasi_common::StringArrayError),
+
+    #[error("host_call: cannot convert bd to UTF8: {0}")]
+    WasiMemOpToUtF8(#[source] std::str::Utf8Error),
+
+    // corresponds to a PoisonError, whose error message is not particularly useful anyways
+    #[error("host_call: cannot write to STDIN")]
+    WasiCannotWriteStdin(),
+
+    // corresponds to a PoisonError, whose error message is not particularly useful anyways
+    #[error("host_call: cannot get write access to STDIN")]
+    WasiWriteAccessStdin(),
+}
+
+impl From<std::convert::Infallible> for WasiRuntimeError {
+    fn from(_: std::convert::Infallible) -> Self {
+        unreachable!()
+    }
 }

--- a/src/runtimes/wasi_cli/errors.rs
+++ b/src/runtimes/wasi_cli/errors.rs
@@ -28,10 +28,10 @@ pub enum WasiRuntimeError {
     WasmInstantiate(#[source] wasmtime::Error),
 
     #[error("cannot find 'mem' export")]
-    WasiMemExport(),
+    WasiMemExport,
 
     #[error("'mem' export cannot be converted into a Memory instance")]
-    WasiMemExportCannotConvert(),
+    WasiMemExportCannotConvert,
 
     #[error("cannot build WasiCtxBuilder: {0}")]
     WasiCtxBuilder(#[source] wasi_common::StringArrayError),
@@ -53,3 +53,19 @@ impl From<std::convert::Infallible> for WasiRuntimeError {
         unreachable!()
     }
 }
+
+// impl From<std::result::Result<std::convert::Infallible, wasmtime::Error>>
+//     for std::result::Result<(), WasiRuntimeError>
+// {
+//     fn from(_: std::convert::Infallible) -> Self {
+//         unreachable!()
+//     }
+// }
+
+// impl Into<std::result::Result<(), WasiRuntimeError>>
+//     for std::result::Result<std::convert::Infallible, wasmtime::Error>
+// {
+//     fn into(_: std::result::Result<(), WasiRuntimeError>) -> Self {
+//         unreachable!()
+//     }
+// }

--- a/src/runtimes/wasi_cli/stack.rs
+++ b/src/runtimes/wasi_cli/stack.rs
@@ -48,7 +48,8 @@ impl Stack {
         let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
 
         let wasi_ctx = WasiCtxBuilder::new()
-            .args(&args)?
+            .args(&args)
+            .map_err(WasiRuntimeError::WasiCtxBuilder)?
             .stdin(Box::new(ReadPipe::from_shared(stdin_pipe.clone())))
             .stdout(Box::new(stdout_pipe.clone()))
             .stderr(Box::new(stderr_pipe.clone()))
@@ -60,10 +61,7 @@ impl Stack {
         };
 
         let mut store = self.stack_pre.build_store(ctx);
-        let instance = self
-            .stack_pre
-            .rehydrate(&mut store)
-            .map_err(WasiRuntimeError::WasmInstantiate)?;
+        let instance = self.stack_pre.rehydrate(&mut store)?;
         let start_fn = instance
             .get_typed_func::<(), ()>(&mut store, "_start")
             .map_err(WasiRuntimeError::WasmMissingStartFn)?;

--- a/src/runtimes/wasi_cli/stack_pre.rs
+++ b/src/runtimes/wasi_cli/stack_pre.rs
@@ -60,56 +60,60 @@ impl StackPre {
 }
 
 fn add_host_call_to_linker(linker: &mut wasmtime::Linker<Context>) -> Result<()> {
-    linker.func_wrap(
-        "host",
-        "call",
-        |mut caller: wasmtime::Caller<'_, Context>,
-         bd_ptr: i32,
-         bd_len: i32,
-         ns_ptr: i32,
-         ns_len: i32,
-         op_ptr: i32,
-         op_len: i32,
-         ptr: i32,
-         len: i32| {
-            let memory_export = caller
-                .get_export("memory")
-                .ok_or_else(|| WasiRuntimeError::WasiMemExport)?;
-            let memory = memory_export
-                .into_memory()
-                .ok_or_else(|| WasiRuntimeError::WasiMemExportCannotConvert)?;
+    linker
+        .func_wrap(
+            "host",
+            "call",
+            |mut caller: wasmtime::Caller<'_, Context>,
+             bd_ptr: i32,
+             bd_len: i32,
+             ns_ptr: i32,
+             ns_len: i32,
+             op_ptr: i32,
+             op_len: i32,
+             ptr: i32,
+             len: i32| {
+                let memory_export = caller
+                    .get_export("memory")
+                    .ok_or_else(|| WasiRuntimeError::WasiMemExport)?;
+                let memory = memory_export
+                    .into_memory()
+                    .ok_or_else(|| WasiRuntimeError::WasiMemExportCannotConvert)?;
 
-            let stdin = caller.data().stdin_pipe.as_ref();
+                let stdin = caller.data().stdin_pipe.as_ref();
 
-            let vec = get_vec_from_memory(caller.as_context(), memory, ptr, len);
-            let bd_vec = get_vec_from_memory(caller.as_context(), memory, bd_ptr, bd_len);
-            let bd = std::str::from_utf8(&bd_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
-            let ns_vec = get_vec_from_memory(caller.as_context(), memory, ns_ptr, ns_len);
-            let ns = std::str::from_utf8(&ns_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
-            let op_vec = get_vec_from_memory(caller.as_context(), memory, op_ptr, op_len);
-            let op = std::str::from_utf8(&op_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
+                let vec = get_vec_from_memory(caller.as_context(), memory, ptr, len);
+                let bd_vec = get_vec_from_memory(caller.as_context(), memory, bd_ptr, bd_len);
+                let bd = std::str::from_utf8(&bd_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
+                let ns_vec = get_vec_from_memory(caller.as_context(), memory, ns_ptr, ns_len);
+                let ns = std::str::from_utf8(&ns_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
+                let op_vec = get_vec_from_memory(caller.as_context(), memory, op_ptr, op_len);
+                let op = std::str::from_utf8(&op_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
 
-            let host_callback_response = host_callback(bd, ns, op, &vec, &caller.data().eval_ctx);
+                let host_callback_response =
+                    host_callback(bd, ns, op, &vec, &caller.data().eval_ctx);
 
-            // return 1 if the host callback failed, 0 otherwise
-            let func_return_value = host_callback_response.is_err() as i32;
+                // return 1 if the host callback failed, 0 otherwise
+                let func_return_value = host_callback_response.is_err() as i32;
 
-            let response_msg = match host_callback_response {
-                Ok(r) => r,
-                Err(e) => e.to_string().as_bytes().to_owned(),
-            };
+                let response_msg = match host_callback_response {
+                    Ok(r) => r,
+                    Err(e) => e.to_string().as_bytes().to_owned(),
+                };
 
-            let mut stdin_pipe = stdin
-                .write()
-                // .map_err(|e| anyhow!("host_call: cannot get write access to STDIN: {e:?}"))?;
-                .map_err(|_| WasiRuntimeError::WasiWriteAccessStdin())?;
-            let _ = stdin_pipe
-                .write(&response_msg)
-                // .map_err(|e| anyhow!("host_call: cannot write to STDIN: {e:?}"))?;
-                .map_err(|_| WasiRuntimeError::WasiCannotWriteStdin())?;
-            Ok(func_return_value)
-        },
-    )?;
+                let mut stdin_pipe = stdin
+                    .write()
+                    .map_err(|_| WasiRuntimeError::WasiWriteAccessStdin())?;
+                let _ = stdin_pipe
+                    .write(&response_msg)
+                    .map_err(|_| WasiRuntimeError::WasiCannotWriteStdin())?;
+                Ok(func_return_value)
+            },
+        )
+        .map_err(|e| WasiRuntimeError::WasmHostFuncDefinitionError {
+            name: "host.call".to_string(),
+            error: e.to_string(),
+        })?;
     Ok(())
 }
 

--- a/src/runtimes/wasi_cli/stack_pre.rs
+++ b/src/runtimes/wasi_cli/stack_pre.rs
@@ -74,10 +74,10 @@ fn add_host_call_to_linker(linker: &mut wasmtime::Linker<Context>) -> Result<()>
          len: i32| {
             let memory_export = caller
                 .get_export("memory")
-                .ok_or_else(|| WasiRuntimeError::WasiMemExport())?;
+                .ok_or_else(|| WasiRuntimeError::WasiMemExport)?;
             let memory = memory_export
                 .into_memory()
-                .ok_or_else(|| WasiRuntimeError::WasiMemExportCannotConvert())?;
+                .ok_or_else(|| WasiRuntimeError::WasiMemExportCannotConvert)?;
 
             let stdin = caller.data().stdin_pipe.as_ref();
 

--- a/src/runtimes/wasi_cli/stack_pre.rs
+++ b/src/runtimes/wasi_cli/stack_pre.rs
@@ -1,6 +1,8 @@
-use anyhow::{anyhow, Result};
 use std::io::Write;
+
 use wasmtime::{AsContext, Engine, InstancePre, Linker, Memory, Module, StoreContext};
+
+use crate::runtimes::wasi_cli::errors::{Result, WasiRuntimeError};
 
 use crate::policy_evaluator_builder::EpochDeadlines;
 use crate::runtimes::{callback::host_callback, wasi_cli::stack::Context};
@@ -20,10 +22,13 @@ impl StackPre {
         epoch_deadlines: Option<EpochDeadlines>,
     ) -> Result<Self> {
         let mut linker = Linker::<Context>::new(&engine);
-        wasmtime_wasi::add_to_linker(&mut linker, |c: &mut Context| &mut c.wasi_ctx)?;
+        wasmtime_wasi::add_to_linker(&mut linker, |c: &mut Context| &mut c.wasi_ctx)
+            .map_err(WasiRuntimeError::WasmLinkerError)?;
         add_host_call_to_linker(&mut linker)?;
 
-        let instance_pre = linker.instantiate_pre(&module)?;
+        let instance_pre = linker
+            .instantiate_pre(&module)
+            .map_err(WasiRuntimeError::WasmInstantiate)?;
         Ok(Self {
             engine,
             instance_pre,
@@ -48,7 +53,9 @@ impl StackPre {
         &self,
         store: &mut wasmtime::Store<Context>,
     ) -> Result<wasmtime::Instance> {
-        self.instance_pre.instantiate(store)
+        self.instance_pre
+            .instantiate(store)
+            .map_err(WasiRuntimeError::WasmInstantiate)
     }
 }
 
@@ -67,23 +74,20 @@ fn add_host_call_to_linker(linker: &mut wasmtime::Linker<Context>) -> Result<()>
          len: i32| {
             let memory_export = caller
                 .get_export("memory")
-                .ok_or_else(|| anyhow!("Cannot find 'mem' export"))?;
-            let memory = memory_export.into_memory().ok_or_else(|| {
-                anyhow!("'mem' export cannot be converted into a Memory instance")
-            })?;
+                .ok_or_else(|| WasiRuntimeError::WasiMemExport())?;
+            let memory = memory_export
+                .into_memory()
+                .ok_or_else(|| WasiRuntimeError::WasiMemExportCannotConvert())?;
 
             let stdin = caller.data().stdin_pipe.as_ref();
 
             let vec = get_vec_from_memory(caller.as_context(), memory, ptr, len);
             let bd_vec = get_vec_from_memory(caller.as_context(), memory, bd_ptr, bd_len);
-            let bd = std::str::from_utf8(&bd_vec)
-                .map_err(|e| anyhow!(format!("host_call: cannot convert bd to UTF8: {:?}", e)))?;
+            let bd = std::str::from_utf8(&bd_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
             let ns_vec = get_vec_from_memory(caller.as_context(), memory, ns_ptr, ns_len);
-            let ns = std::str::from_utf8(&ns_vec)
-                .map_err(|e| anyhow!(format!("host_call: cannot convert ns to UTF8: {:?}", e)))?;
+            let ns = std::str::from_utf8(&ns_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
             let op_vec = get_vec_from_memory(caller.as_context(), memory, op_ptr, op_len);
-            let op = std::str::from_utf8(&op_vec)
-                .map_err(|e| anyhow!(format!("host_call: cannot convert op to UTF8: {:?}", e)))?;
+            let op = std::str::from_utf8(&op_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
 
             let host_callback_response = host_callback(bd, ns, op, &vec, &caller.data().eval_ctx);
 
@@ -97,11 +101,12 @@ fn add_host_call_to_linker(linker: &mut wasmtime::Linker<Context>) -> Result<()>
 
             let mut stdin_pipe = stdin
                 .write()
-                .map_err(|e| anyhow!("host_call: cannot get write access to STDIN: {e:?}"))?;
+                // .map_err(|e| anyhow!("host_call: cannot get write access to STDIN: {e:?}"))?;
+                .map_err(|_| WasiRuntimeError::WasiWriteAccessStdin())?;
             let _ = stdin_pipe
                 .write(&response_msg)
-                .map_err(|e| anyhow!("host_call: cannot write to STDIN: {e:?}"))?;
-
+                // .map_err(|e| anyhow!("host_call: cannot write to STDIN: {e:?}"))?;
+                .map_err(|_| WasiRuntimeError::WasiCannotWriteStdin())?;
             Ok(func_return_value)
         },
     )?;


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/policy-evaluator/issues/377

Opening this as draft for easy discussion.

Currently, it fails as it is expected that WasiRuntimeError can be converted from `std::result::Result<std::convert::Infallible, wasmtime::Error>`.

 <!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
