### PR TITLE
ci: Add codecov support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,3 +84,38 @@ jobs:
         with:
           command: clippy
           args: --workspace -- -D warnings
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4.0.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: taiki-e/install-action@0dffe805566eb5f21aa682f9a43f6fbac7282dbe # v2.26.16
+        with:
+          tool: cargo-tarpaulin
+      - name: Generate unit-tests coverage
+        run: make coverage-unit-tests
+      - name: Upload unit-tests coverage to Codecov
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        with:
+          name: unit-tests
+          directory: coverage/unit-tests
+          flags: unit-tests
+          verbose: true
+      - name: Generate integration-tests coverage
+        run: make coverage-integration-tests
+      - name: Upload unit-tests coverage to Codecov
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        with:
+          name: integration-tests
+          directory: coverage/integration-tests
+          flags: integration-tests
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 Cargo.lock
+
+# coverage instrumentation:
+*.profraw

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,24 @@ unit-tests: fmt lint
 integration-tests: fmt lint
 	cargo test --test '*'
 
+
+.PHONY: coverage
+coverage: coverage-unit-tests coverage-integration-tests
+	
+.PHONY: coverage-unit-tests
+coverage-unit-tests:
+	# integration-tests with llvm need +nightly. Hence, enable +nightly on
+	# unit-tests, and use --skip-clean to not recompile on CI if not needed
+	cargo +nightly tarpaulin --verbose --skip-clean --engine=llvm \
+		--all-features --lib --bin --follow-exec \
+		--out xml --out html --output-dir coverage/unit-tests
+	
+.PHONY: coverage-integration-tests
+coverage-integration-tests:
+	cargo +nightly tarpaulin --verbose --skip-clean --engine=llvm \
+		--all-features --test integration_test --examples --doc --benches --follow-exec \
+		--out xml --out html --output-dir coverage/integration-tests
+
 .PHONY: clean
 clean:
 	cargo clean

--- a/coverage/integration-tests/.gitignore
+++ b/coverage/integration-tests/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/coverage/unit-tests/.gitignore
+++ b/coverage/unit-tests/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
## Description

Add new make targets `coverage, `coverage-unit-tests`, `coverage-integration-tests` that are used in the CI. They run the tests via `cargo-tarpaulin` with llvm, and save the reports to the respective new folders `coverage/{unit-tests,integration-tests}/*`.

The make targets are both configured with `cargo +nightly`, as `cargo-tarpaulin` for the integration-tests need it, and in this way we can skip recompiling again. 

Add new CI job that runs the tests via the new makefile targets and uploads the result to codecov.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI, PR should get a "welcome to codecov" message, and audit-scanner appear under https://app.codecov.io/github/kubewarden/.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
