### PR TITLE
Tag 0.16.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.14.2"
+version = "0.16.0"
 
 [workspace]
 members = ["crates/burrego"]


### PR DESCRIPTION
This is a minor bump because we changed the way kubernetes resources are retrieved by context aware policies.
We now implement the "informer pattern", see https://github.com/kubewarden/kubewarden-controller/issues/575

Note: when 0.15.0 was tagged, the `Cargo.toml` file was **not** updated. That's why we are jumping from 0.14.x -> 0.16
