### PR TITLE
gatekeeper inventory optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ kube = { version = "0.88.1", default-features = false, features = [
   "runtime",
 ] }
 kubewarden-policy-sdk = "0.10.0"
+lazy_static = "1.4"
 mail-parser = { version = "0.9.2", features = ["serde"] }
 picky = { version = "7.0.0-rc.8", default-features = false, features = [
   "chrono_conversion",
@@ -65,6 +66,7 @@ k8s-openapi = { version = "0.21.1", default-features = false, features = [
   "v1_28",
 ] }
 rstest = "0.18"
+serial_test = "3.0"
 test-context = "0.3"
 tempfile = "3.8.1"
 tower-test = "0.4"

--- a/crates/burrego/examples/cli/main.rs
+++ b/crates/burrego/examples/cli/main.rs
@@ -104,8 +104,6 @@ fn main() -> Result<()> {
                 json!({})
             };
 
-            let data_value: serde_json::Value =
-                serde_json::from_str(data).map_err(|e| anyhow!("Cannot parse data: {:?}", e))?;
             let mut evaluator = burrego::EvaluatorBuilder::default()
                 .policy_path(&PathBuf::from(policy))
                 .host_callbacks(burrego::HostCallbacks::default())
@@ -131,7 +129,8 @@ fn main() -> Result<()> {
                 _ => evaluator.entrypoint_id(&String::from(entrypoint))?,
             };
 
-            let evaluation_res = evaluator.evaluate(entrypoint_id, &input_value, &data_value)?;
+            let evaluation_res =
+                evaluator.evaluate(entrypoint_id, &input_value, data.as_bytes())?;
             println!("{}", serde_json::to_string_pretty(&evaluation_res)?);
             Ok(())
         }

--- a/crates/burrego/src/errors.rs
+++ b/crates/burrego/src/errors.rs
@@ -16,6 +16,7 @@ pub enum BurregoError {
     #[error("{msg}: {source}")]
     JSONError {
         msg: String,
+        #[source]
         source: serde_json::Error,
     },
 

--- a/crates/burrego/src/errors.rs
+++ b/crates/burrego/src/errors.rs
@@ -13,8 +13,11 @@ pub enum BurregoError {
     #[error("Rego wasm error: {0}")]
     RegoWasmError(String),
 
-    #[error("JSON error: {0}")]
-    JSONError(String),
+    #[error("{msg}: {source}")]
+    JSONError {
+        msg: String,
+        source: serde_json::Error,
+    },
 
     #[error("Evaluator builder error: {0}")]
     EvaluatorBuilderError(String),

--- a/crates/burrego/src/evaluator.rs
+++ b/crates/burrego/src/evaluator.rs
@@ -231,7 +231,7 @@ impl Evaluator {
         &mut self,
         entrypoint_id: i32,
         input: &serde_json::Value,
-        data: &serde_json::Value,
+        data: &[u8],
     ) -> Result<serde_json::Value> {
         set_epoch_deadline_and_call_guest!(self.epoch_deadline, self.store, {
             if !self.has_entrypoint(entrypoint_id) {

--- a/crates/burrego/src/policy.rs
+++ b/crates/burrego/src/policy.rs
@@ -216,12 +216,12 @@ impl Policy {
         &mut self,
         mut store: impl AsContextMut,
         memory: &Memory,
-        data: &serde_json::Value,
+        data: &[u8],
     ) -> Result<()> {
         self.opa_heap_ptr_set_fn
             .call(store.as_context_mut(), self.base_heap_ptr)
             .map_err(|e| map_call_error!(e, "error invoking opa_heap_ptr_set function"))?;
-        self.data_addr = StackHelper::push_json(
+        self.data_addr = StackHelper::push_json_raw(
             store.as_context_mut(),
             memory,
             self.opa_malloc_fn,

--- a/src/callback_handler.rs
+++ b/src/callback_handler.rs
@@ -296,6 +296,29 @@ impl CallbackHandler {
                         }
                     )
                 }
+                CallbackRequestType::HasKubernetesListResourceAllResultChangedSinceInstant {
+                    api_version,
+                    kind,
+                    label_selector,
+                    field_selector,
+                    since,
+                } => {
+                    handle_callback!(
+                        req,
+                        format!("{api_version}/{kind}"),
+                        "Has the result of 'Kubernetes list all resources' changed since a given instant",
+                        {
+                            kubernetes::has_list_resources_all_result_changed_since_instant(
+                                kubernetes_client.as_mut(),
+                                &api_version,
+                                &kind,
+                                label_selector,
+                                field_selector,
+                                since,
+                            )
+                        }
+                    )
+                }
             }
         });
     }

--- a/src/callback_handler/kubernetes.rs
+++ b/src/callback_handler/kubernetes.rs
@@ -116,3 +116,30 @@ pub(crate) async fn get_resource_plural_name(
             value,
         })
 }
+
+/// Check if the results of the "list all resources" query have changed since the provided instant
+/// This is done by querying the reflector that keeps track of this query
+pub(crate) async fn has_list_resources_all_result_changed_since_instant(
+    client: Option<&mut Client>,
+    api_version: &str,
+    kind: &str,
+    label_selector: Option<String>,
+    field_selector: Option<String>,
+    since: tokio::time::Instant,
+) -> Result<cached::Return<bool>> {
+    if client.is_none() {
+        return Err(anyhow!("kube::Client was not initialized properly")).map(cached::Return::new);
+    }
+
+    client
+        .unwrap()
+        .has_list_resources_all_result_changed_since_instant(
+            api_version,
+            kind,
+            label_selector,
+            field_selector,
+            since,
+        )
+        .await
+        .map(cached::Return::new)
+}

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -177,7 +177,7 @@ pub enum CallbackRequestType {
         kind: String,
     },
 
-    /// Is the data of the reflector tracking this query changed since the given instant?
+    /// Checks if the data of the reflector tracking this query changed since the given instant
     HasKubernetesListResourceAllResultChangedSinceInstant {
         /// apiVersion of the resource (v1 for core group, groupName/groupVersions for other).
         api_version: String,

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
-use kubewarden_policy_sdk::host_capabilities::verification::{KeylessInfo, KeylessPrefixInfo};
 use kubewarden_policy_sdk::host_capabilities::{
+    verification::{KeylessInfo, KeylessPrefixInfo},
     SigstoreVerificationInputV1, SigstoreVerificationInputV2,
 };
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tokio::sync::oneshot;
+use tokio::{sync::oneshot, time::Instant};
 
 /// Holds the response to a waPC evaluation request
 #[derive(Debug, Clone)]
@@ -26,7 +25,7 @@ pub struct CallbackRequest {
 
 /// Describes the different kinds of request a waPC guest can make to
 /// our host.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum CallbackRequestType {
     /// Require the computation of the manifest digest of an OCI object (be
     /// it an image or anything else that can be stored into an OCI registry)
@@ -176,6 +175,22 @@ pub enum CallbackRequestType {
         api_version: String,
         /// Singular PascalCase name of the resource
         kind: String,
+    },
+
+    /// Is the data of the reflector tracking this query changed since the given instant?
+    HasKubernetesListResourceAllResultChangedSinceInstant {
+        /// apiVersion of the resource (v1 for core group, groupName/groupVersions for other).
+        api_version: String,
+        /// Singular PascalCase name of the resource
+        kind: String,
+        /// A selector to restrict the list of returned objects by their labels.
+        /// Defaults to everything if `None`
+        label_selector: Option<String>,
+        /// A selector to restrict the list of returned objects by their fields.
+        /// Defaults to everything if `None`
+        field_selector: Option<String>,
+        /// The instant in time to compare the last change of the resources
+        since: Instant,
     },
 }
 

--- a/src/runtimes/rego/errors.rs
+++ b/src/runtimes/rego/errors.rs
@@ -10,6 +10,9 @@ pub enum RegoRuntimeError {
     #[error("cannot convert callback response into a list of kubernetes objects: {0}")]
     CallbackConvertList(#[source] serde_json::Error),
 
+    #[error("cannot convert callback response into a boolean: {0}")]
+    CallbackConvertBool(#[source] serde_json::Error),
+
     #[error("error sending request over callback channel: {0}")]
     CallbackSend(String), // TODO same as CallbackRequest?
 
@@ -27,6 +30,9 @@ pub enum RegoRuntimeError {
 
     #[error("DynamicObject does not have a namespace")]
     GatekeeperInventoryMissingNamespace,
+
+    #[error("cannot convert Gatekeeper inventory to JSON: {0}")]
+    GatekeeperInventorySerializationError(#[source] serde_json::Error),
 
     #[error("DynamicObject does not have a name")]
     OpaInventoryMissingName,

--- a/src/runtimes/rego/gatekeeper_inventory.rs
+++ b/src/runtimes/rego/gatekeeper_inventory.rs
@@ -56,7 +56,7 @@
 /// ```
 ///
 use kube::api::ObjectList;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use crate::policy_metadata::ContextAwareResource;
@@ -64,7 +64,7 @@ use crate::runtimes::rego::errors::{RegoRuntimeError, Result};
 
 /// A wrapper around a dictionary that has the resource Name as key,
 /// and a DynamicObject as value
-#[derive(Serialize, Default)]
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub(crate) struct ResourcesByName(BTreeMap<String, kube::core::DynamicObject>);
 
 impl ResourcesByName {
@@ -81,7 +81,7 @@ impl ResourcesByName {
 
 /// A wrapper around a dictionary that has a Kubernetes Kind (e.g. `Pod`)
 /// as key, and a ResourcesByName as value
-#[derive(Serialize, Default)]
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub(crate) struct ResourcesByKind(BTreeMap<String, ResourcesByName>);
 
 impl ResourcesByKind {
@@ -99,7 +99,7 @@ impl ResourcesByKind {
 
 /// A wrapper around a dictionary that has a Kubernetes GroupVersion (e.g. `apps/v1`)
 /// as key, and a ResourcesByKind as value
-#[derive(Serialize, Default)]
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub(crate) struct ResourcesByGroupVersion(BTreeMap<String, ResourcesByKind>);
 
 impl ResourcesByGroupVersion {
@@ -118,7 +118,7 @@ impl ResourcesByGroupVersion {
 /// A wrapper around a dictionary that has
 /// the name of a Kubernetes Namespace (e.g. `kube-system`) as key,
 /// and a ResourcesByGroupVersion as value
-#[derive(Serialize, Default)]
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub(crate) struct ResourcesByNamespace(BTreeMap<String, ResourcesByGroupVersion>);
 
 impl ResourcesByNamespace {
@@ -138,7 +138,7 @@ impl ResourcesByNamespace {
 
 /// A struct holding the Kubernetes context aware data in a format that is compabible with what
 /// Gatekeeper expects
-#[derive(Serialize, Default)]
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub(crate) struct GatekeeperInventory {
     #[serde(rename = "cluster")]
     cluster_resources: ResourcesByGroupVersion,

--- a/src/runtimes/rego/gatekeeper_inventory_cache.rs
+++ b/src/runtimes/rego/gatekeeper_inventory_cache.rs
@@ -1,0 +1,381 @@
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::{Arc, RwLock},
+};
+use tokio::{sync::mpsc, time::Instant};
+
+use crate::runtimes::rego::context_aware::{
+    get_allowed_resources, have_allowed_resources_changed_since_instant,
+};
+use crate::{
+    callback_requests::CallbackRequest,
+    policy_metadata::ContextAwareResource,
+    runtimes::rego::{
+        errors::{RegoRuntimeError, Result},
+        gatekeeper_inventory::GatekeeperInventory,
+    },
+};
+
+lazy_static! {
+    /// Global cache for the Gatekeeper inventories
+    pub(crate) static ref GATEKEEPER_INVENTORY_CACHE: GateKeeperInventoryCache =
+        GateKeeperInventoryCache::new();
+}
+
+/// A serialized Gatekeeper inventory. Building and serializing the inventory can
+/// be quite expensive when many Kubernetes resources are involved. This cache
+/// is used to avoid recomputing the inventory on every request.
+#[derive(Clone)]
+pub(crate) struct CachedInventory {
+    /// The serialized inventory
+    pub data: Vec<u8>,
+    /// The instant when the inventory was last computed. This is used to invalidate the cache
+    pub cache_time: Instant,
+}
+
+/// This defines how Gatekeeper policy expects the `input` attribute to be structured.
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct GatekeeperInput {
+    /// The actual inventory
+    inventory: GatekeeperInventory,
+}
+
+/// Hold all the inventories for the Gatekeeper runtime
+///
+/// The inventories are stored inside of a dictionary that has the list of resources
+/// the inventory is allowed to access as key. The value is the serialized inventory.
+///
+/// Two different policies that access the same set of resources will share the same
+/// inventory.
+/// However, two policies sharing an overlapping set of resources will have different
+/// inventories, leading to some duplication of information.
+/// Unfortunately there's nothing we can do to prevent that. We need to keep in cache
+/// the serialized version of the inventories to speed up the policy evaluation.
+pub(crate) struct GateKeeperInventoryCache {
+    // Note: the Arc is used to make some `clone` invocation faster. The `clone` operations
+    // are required because the whole `inventories` variable is located inside of a RwLock
+    inventories: RwLock<HashMap<BTreeSet<ContextAwareResource>, Arc<CachedInventory>>>,
+}
+
+impl GateKeeperInventoryCache {
+    pub fn new() -> Self {
+        Self {
+            inventories: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// This function returns the serialized inventory for the given set of resources.
+    /// The inventory is computed and serialized only if it's not already present in the cache.
+    /// The inventory is also recreated if the set of resources has changed since the time
+    /// the inventory was computed
+    pub fn get_inventory(
+        &self,
+        callback_channel: &mpsc::Sender<CallbackRequest>,
+        ctx_aware_resources: &BTreeSet<ContextAwareResource>,
+    ) -> Result<Vec<u8>> {
+        let inventory = {
+            let inventories = self.inventories.read().unwrap();
+            inventories.get(ctx_aware_resources).cloned()
+        };
+        let inventory = match inventory {
+            None => self.create_and_register_inventory(ctx_aware_resources, callback_channel),
+            Some(cached_inventory) => {
+                if have_allowed_resources_changed_since_instant(
+                    callback_channel,
+                    ctx_aware_resources,
+                    cached_inventory.cache_time,
+                )? {
+                    self.create_and_register_inventory(ctx_aware_resources, callback_channel)
+                } else {
+                    Ok(cached_inventory)
+                }
+            }
+        }?;
+        Ok(inventory.data.clone())
+    }
+
+    /// Create the inventory and register it in the cache. A prior entry of the inventory is
+    /// automatically removed from the cache.
+    fn create_and_register_inventory(
+        &self,
+        ctx_aware_resources: &BTreeSet<ContextAwareResource>,
+        callback_channel: &mpsc::Sender<CallbackRequest>,
+    ) -> Result<Arc<CachedInventory>> {
+        let now = Instant::now();
+        let cluster_resources = get_allowed_resources(callback_channel, ctx_aware_resources)?;
+        let inventory = GatekeeperInput {
+            inventory: GatekeeperInventory::new(&cluster_resources)?,
+        };
+        let cached_inventory = Arc::new(CachedInventory {
+            data: serde_json::to_vec(&inventory)
+                .map_err(RegoRuntimeError::GatekeeperInventorySerializationError)?,
+            cache_time: now,
+        });
+
+        self.inventories
+            .write()
+            .unwrap()
+            .insert(ctx_aware_resources.to_owned(), cached_inventory.clone());
+        Ok(cached_inventory)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::callback_requests::{CallbackRequestType, CallbackResponse};
+    use serial_test::serial;
+    use std::collections::BTreeMap;
+
+    use crate::runtimes::rego::context_aware::tests::{
+        dynamic_object_from_fixture, object_list_from_dynamic_objects,
+    };
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn test_create_entry_because_cache_does_not_exist() {
+        let (callback_tx, mut callback_rx) = mpsc::channel::<CallbackRequest>(10);
+        let resource = ContextAwareResource {
+            api_version: "v1".to_string(),
+            kind: "Service".to_string(),
+        };
+        let expected_resource = resource.clone();
+        let services = [
+            dynamic_object_from_fixture("services", Some("kube-system"), "kube-dns").unwrap(),
+            dynamic_object_from_fixture("services", Some("kube-system"), "metrics-server").unwrap(),
+        ];
+        let services_list = object_list_from_dynamic_objects(&services).unwrap();
+        let kube_resources = BTreeMap::from([(resource.clone(), services_list.clone())]);
+        let expected_inventory = GatekeeperInventory::new(&kube_resources).unwrap();
+
+        tokio::spawn(async move {
+            loop {
+                let req = match callback_rx.recv().await {
+                    Some(r) => r,
+                    None => return,
+                };
+                let callback_response = match req.request {
+                    CallbackRequestType::KubernetesListResourceAll {
+                        api_version,
+                        kind,
+                        label_selector,
+                        field_selector,
+                    } => {
+                        assert_eq!(api_version, expected_resource.api_version);
+                        assert_eq!(kind, expected_resource.kind);
+                        assert!(label_selector.is_none());
+                        assert!(field_selector.is_none());
+                        CallbackResponse {
+                            payload: serde_json::to_vec(&services_list).unwrap(),
+                        }
+                    }
+                    _ => {
+                        panic!("not the expected request type");
+                    }
+                };
+
+                req.response_channel.send(Ok(callback_response)).unwrap();
+            }
+        });
+
+        tokio::task::spawn_blocking(move || {
+            {
+                // ensure the cache is empty
+                let mut inventories = GATEKEEPER_INVENTORY_CACHE.inventories.write().unwrap();
+                inventories.clear();
+            }
+
+            let resources: BTreeSet<ContextAwareResource> = BTreeSet::from([resource]);
+
+            let cached_inventory = GATEKEEPER_INVENTORY_CACHE
+                .get_inventory(&callback_tx, &resources)
+                .unwrap();
+            assert!(!cached_inventory.is_empty());
+
+            {
+                let inventories = GATEKEEPER_INVENTORY_CACHE.inventories.read().unwrap();
+                let cached_input_json = inventories.get(&resources).unwrap();
+                let actual_inventory =
+                    serde_json::from_slice::<GatekeeperInput>(&cached_input_json.data)
+                        .unwrap()
+                        .inventory;
+                assert_eq!(expected_inventory, actual_inventory);
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn test_cached_entry_is_still_valid() {
+        let (callback_tx, mut callback_rx) = mpsc::channel::<CallbackRequest>(10);
+        let resource = ContextAwareResource {
+            api_version: "v1".to_string(),
+            kind: "Service".to_string(),
+        };
+        let expected_resource = resource.clone();
+
+        let resources: BTreeSet<ContextAwareResource> = BTreeSet::from([resource.clone()]);
+
+        let expected_cached_inventory = CachedInventory {
+            data: "cached_inventory".as_bytes().to_vec(),
+            cache_time: Instant::now()
+                .checked_sub(tokio::time::Duration::from_secs(60))
+                .unwrap(),
+        };
+        {
+            let mut inventories = GATEKEEPER_INVENTORY_CACHE.inventories.write().unwrap();
+            inventories.insert(
+                resources.clone(),
+                Arc::new(expected_cached_inventory.clone()),
+            );
+        }
+
+        tokio::spawn(async move {
+            loop {
+                let req = match callback_rx.recv().await {
+                    Some(r) => r,
+                    None => return,
+                };
+                let callback_response = match req.request {
+                    CallbackRequestType::HasKubernetesListResourceAllResultChangedSinceInstant {
+                        api_version,
+                        kind,
+                        label_selector,
+                        field_selector,
+                        since: _,
+                    } => {
+                        assert_eq!(api_version, expected_resource.api_version);
+                        assert_eq!(kind, expected_resource.kind);
+                        assert!(label_selector.is_none());
+                        assert!(field_selector.is_none());
+
+                        CallbackResponse {
+                            payload: serde_json::to_vec(&false).unwrap(),
+                        }
+                    }
+                    _ => {
+                        panic!("not the expected request type");
+                    }
+                };
+
+                req.response_channel.send(Ok(callback_response)).unwrap();
+            }
+        });
+
+        tokio::task::spawn_blocking(move || {
+            let actual = GATEKEEPER_INVENTORY_CACHE
+                .get_inventory(&callback_tx, &resources)
+                .unwrap();
+            assert_eq!(expected_cached_inventory.data, actual);
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn test_cached_entry_is_no_longer_valid() {
+        let (callback_tx, mut callback_rx) = mpsc::channel::<CallbackRequest>(10);
+        let resource = ContextAwareResource {
+            api_version: "v1".to_string(),
+            kind: "Service".to_string(),
+        };
+        let expected_resource = resource.clone();
+
+        let resources: BTreeSet<ContextAwareResource> = BTreeSet::from([resource.clone()]);
+
+        let services = [
+            dynamic_object_from_fixture("services", Some("kube-system"), "kube-dns").unwrap(),
+            dynamic_object_from_fixture("services", Some("kube-system"), "metrics-server").unwrap(),
+        ];
+        let services_list = object_list_from_dynamic_objects(&services).unwrap();
+
+        let kube_resources = BTreeMap::from([(resource, services_list.clone())]);
+        let expected_inventory = GatekeeperInventory::new(&kube_resources).unwrap();
+
+        let stale_cached_inventory = CachedInventory {
+            data: b"cached_inventory_stale".to_vec(),
+            cache_time: Instant::now()
+                .checked_sub(tokio::time::Duration::from_secs(60))
+                .unwrap(),
+        };
+
+        {
+            let mut inventories = GATEKEEPER_INVENTORY_CACHE.inventories.write().unwrap();
+            inventories.insert(resources.clone(), Arc::new(stale_cached_inventory.clone()));
+        }
+
+        tokio::spawn(async move {
+            loop {
+                let req = match callback_rx.recv().await {
+                    Some(r) => r,
+                    None => return,
+                };
+                let callback_response = match req.request {
+                    CallbackRequestType::KubernetesListResourceAll {
+                        api_version,
+                        kind,
+                        label_selector,
+                        field_selector,
+                    } => {
+                        assert_eq!(api_version, expected_resource.api_version);
+                        assert_eq!(kind, expected_resource.kind);
+                        assert!(label_selector.is_none());
+                        assert!(field_selector.is_none());
+                        CallbackResponse {
+                            payload: serde_json::to_vec(&services_list).unwrap(),
+                        }
+                    }
+                    CallbackRequestType::HasKubernetesListResourceAllResultChangedSinceInstant {
+                        api_version,
+                        kind,
+                        label_selector,
+                        field_selector,
+                        since: _,
+                    } => {
+                        assert_eq!(api_version, expected_resource.api_version);
+                        assert_eq!(kind, expected_resource.kind);
+                        assert!(label_selector.is_none());
+                        assert!(field_selector.is_none());
+
+                        CallbackResponse {
+                            payload: serde_json::to_vec(&true).unwrap(),
+                        }
+                    }
+                    _ => {
+                        panic!("not the expected request type");
+                    }
+                };
+
+                req.response_channel.send(Ok(callback_response)).unwrap();
+            }
+        });
+
+        tokio::task::spawn_blocking(move || {
+            let actual = GATEKEEPER_INVENTORY_CACHE
+                .get_inventory(&callback_tx, &resources)
+                .unwrap();
+            assert!(actual != stale_cached_inventory.data);
+            let actual_inventory = serde_json::from_slice::<GatekeeperInput>(&actual).unwrap();
+            assert_eq!(expected_inventory, actual_inventory.inventory);
+
+            {
+                let inventories = GATEKEEPER_INVENTORY_CACHE.inventories.read().unwrap();
+                let actual_inventory = inventories.get(&resources).unwrap();
+                assert!(actual_inventory.cache_time > stale_cached_inventory.cache_time);
+            }
+
+            {
+                let inventories = GATEKEEPER_INVENTORY_CACHE.inventories.read().unwrap();
+                let actual_inventory = inventories.get(&resources).unwrap();
+                assert!(actual_inventory.cache_time > stale_cached_inventory.cache_time);
+            }
+        })
+        .await
+        .unwrap();
+    }
+}

--- a/src/runtimes/rego/mod.rs
+++ b/src/runtimes/rego/mod.rs
@@ -1,6 +1,7 @@
 mod context_aware;
 pub mod errors;
 mod gatekeeper_inventory;
+mod gatekeeper_inventory_cache;
 mod opa_inventory;
 mod runtime;
 mod stack;


### PR DESCRIPTION
Cache the serialized version of a Gatekeeper policy for later reuse. This is going to reduce the evaluation time of Gatekeeper policy that make use of context aware data.

Fixes https://github.com/kubewarden/policy-server/issues/704
