### PR TITLE
Tag new patch release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.16.2"
+version = "0.16.3"
 
 [workspace]
 members = ["crates/burrego"]


### PR DESCRIPTION
Create the 0.16.3 release, this is required to fix some build issues with policy-server and kwctl
