### PR TITLE
build(deps): update validator requirement from 0.16 to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ time = { version = "0.3.34", features = ["serde-human-readable"] }
 tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = { version = "2.2", features = ["serde"] }
-validator = { version = "0.16", features = ["derive"] }
+validator = { version = "0.18", features = ["derive"] }
 wapc = "1.1"
 wasi-common = { workspace = true }
 wasmparser = "0.202"

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -27,15 +27,15 @@ pub enum Operation {
 #[derive(Deserialize, Serialize, Debug, Clone, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct Rule {
-    #[validate(length(min = 1), custom = "validate_asterisk_usage")]
+    #[validate(length(min = 1), custom(function = "validate_asterisk_usage"))]
     pub api_groups: Vec<String>,
-    #[validate(length(min = 1), custom = "validate_asterisk_usage")]
+    #[validate(length(min = 1), custom(function = "validate_asterisk_usage"))]
     pub api_versions: Vec<String>,
-    #[validate(length(min = 1), custom = "validate_resources")]
+    #[validate(length(min = 1), custom(function = "validate_resources"))]
     pub resources: Vec<String>,
     #[validate(
         length(min = 1),
-        custom = "validate_asterisk_usage_inside_of_operations"
+        custom(function = "validate_asterisk_usage_inside_of_operations")
     )]
     pub operations: Vec<Operation>,
 }
@@ -151,7 +151,7 @@ impl Display for PolicyType {
 pub struct Metadata {
     #[validate(required)]
     pub protocol_version: Option<ProtocolVersion>,
-    #[validate]
+    #[validate(nested)]
     pub rules: Vec<Rule>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<HashMap<String, String>>,
@@ -163,7 +163,7 @@ pub struct Metadata {
     #[serde(default)]
     pub policy_type: PolicyType,
     #[serde(default)]
-    #[validate]
+    #[validate(nested)]
     pub context_aware_resources: BTreeSet<ContextAwareResource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minimum_kubewarden_version: Option<Version>,


### PR DESCRIPTION
## Description

Updates the validator requirement to 0.18. Fixing all compilations issues caused by the last release of the `validator` crate.

Supersedes https://github.com/kubewarden/policy-evaluator/pull/453