### PR TITLE
fix: address changes done to Sigstore TUF repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ picky = { version = "7.0.0-rc.8", default-features = false, features = [
   "chrono_conversion",
   "x509",
 ] }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.8.3" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.8.4" }
 semver = { version = "1.0.22", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -265,6 +265,7 @@ async fn test_runtime_context_aware<F, Fut>(
     let mut callback_handler = callback_builder
         .kube_client(client)
         .build()
+        .await
         .expect("cannot build callback handler");
     let callback_handler_channel = callback_handler.sender_channel();
 
@@ -326,6 +327,7 @@ async fn test_oci_manifest_capability(
     let callback_builder = CallbackHandlerBuilder::new(callback_handler_shutdown_channel_rx);
     let mut callback_handler = callback_builder
         .build()
+        .await
         .expect("cannot build callback handler");
     let callback_handler_channel = callback_handler.sender_channel();
 


### PR DESCRIPTION
The Sigstore project changed the internals of its TUF repository, which broke sigstore-rs.

This commit updates to the latest version of sigstore-rs. The code changes have been caused by the massive changes done by sigstore-rs.

Required to fix https://github.com/kubewarden/kwctl/issues/753
