### PR TITLE
fix: reflector initial list error handling

### DIFF
--- a/src/callback_handler/kubernetes/reflector.rs
+++ b/src/callback_handler/kubernetes/reflector.rs
@@ -25,6 +25,9 @@ where
 {
     stream
         .take_while(|event| {
+            // InitialListFailed is returned when the initial list of objects failed to be fetched.
+            // In this case, we should break the stream and return an error to the caller.
+            // For all other errors, we should continue the stream, as the watch will be retried.
             if let Err(watcher::Error::InitialListFailed(err)) = event {
                 error!(error = ?err, "watcher error: initial list failed");
                 ready(false)

--- a/tests/k8s_mock/mod.rs
+++ b/tests/k8s_mock/mod.rs
@@ -13,21 +13,62 @@ pub(crate) async fn wapc_and_wasi_scenario(handle: Handle<Request<Body>, Respons
 
         loop {
             let (request, send) = handle.next_request().await.expect("service not called");
+            let url = url::Url::parse(&format!("https://localhost{}", request.uri()))
+                .expect("cannot parse incoming request");
 
-            match (request.method(), request.uri().path()) {
-                (&http::Method::GET, "/api/v1") => {
+            let query_params: HashMap<String, String> = url.query_pairs().into_owned().collect();
+            let is_watch_request = query_params.contains_key("watch");
+            let watch_resource_version = query_params.get("resourceVersion");
+            let label_selector = query_params.get("labelSelector").map(String::as_str);
+
+            println!("request: {:?}", request.uri());
+
+            match (
+                request.method(),
+                request.uri().path(),
+                label_selector,
+                is_watch_request,
+            ) {
+                (&http::Method::GET, "/api/v1", None, false) => {
                     send_response(send, fixtures::v1_resource_list());
                 }
-                (&http::Method::GET, "/apis/apps/v1") => {
+                (&http::Method::GET, "/apis/apps/v1", None, false) => {
                     send_response(send, fixtures::apps_v1_resource_list());
                 }
-                (&http::Method::GET, "/api/v1/namespaces") => {
+                (&http::Method::GET, "/api/v1/namespaces", Some("customer-id=1"), false) => {
                     send_response(send, fixtures::namespaces());
                 }
-                (&http::Method::GET, "/apis/apps/v1/namespaces/customer-1/deployments") => {
+                (&http::Method::GET, "/api/v1/namespaces", Some("customer-id=1"), true) => {
+                    send_response(
+                        send,
+                        fixtures::namespaces_watch_bookmark(watch_resource_version.unwrap()),
+                    );
+                }
+                (
+                    &http::Method::GET,
+                    "/apis/apps/v1/namespaces/customer-1/deployments",
+                    None,
+                    false,
+                ) => {
                     send_response(send, fixtures::deployments());
                 }
-                (&http::Method::GET, "/api/v1/namespaces/customer-1/services/api-auth-service") => {
+                (
+                    &http::Method::GET,
+                    "/apis/apps/v1/namespaces/customer-1/deployments",
+                    None,
+                    true,
+                ) => {
+                    send_response(
+                        send,
+                        fixtures::deployments_watch_bookmark(watch_resource_version.unwrap()),
+                    );
+                }
+                (
+                    &http::Method::GET,
+                    "/api/v1/namespaces/customer-1/services/api-auth-service",
+                    None,
+                    false,
+                ) => {
                     send_response(send, fixtures::api_auth_service());
                 }
                 _ => {


### PR DESCRIPTION
## Description

This is a "backport" of a fix that will be included as a part of:  https://github.com/kubewarden/policy-server/issues/716
Fixes #489 

## Tests
Improves wapc/wasi integration tests by adding the right watch mock API response.
Also, it adds a scenario to test the reflector initialization error.

## Note

In this implementation we are just circuit-breaking the stream, this means a generic error will be returned to the client.
This is a temporary trade-off since we are still using the default `Writer` from `kube-rs` which has its ready channel.
In `1.13` we will implement our custom writer, and the ready channel will be extended to return a result, therefore the user will receive a custom error. 