### PR TITLE
fix: revert break reflector stream on InitialListFailed error

### DIFF
--- a/src/callback_handler/kubernetes/reflector.rs
+++ b/src/callback_handler/kubernetes/reflector.rs
@@ -7,7 +7,7 @@ use kube::{
 };
 use std::hash::Hash;
 use tokio::{sync::watch, time::Instant};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::callback_handler::kubernetes::KubeResource;
 
@@ -23,24 +23,12 @@ where
     K::DynamicType: Eq + Hash + Clone,
     W: Stream<Item = watcher::Result<watcher::Event<K>>>,
 {
-    stream
-        .take_while(|event| {
-            // InitialListFailed is returned when the initial list of objects failed to be fetched.
-            // In this case, we should break the stream and return an error to the caller.
-            // For all other errors, we should continue the stream, as the watch will be retried.
-            if let Err(watcher::Error::InitialListFailed(err)) = event {
-                error!(error = ?err, "watcher error: initial list failed");
-                ready(false)
-            } else {
-                ready(true)
-            }
-        })
-        .inspect_ok(move |event| {
-            if let Err(err) = last_change_seen_at.send(Instant::now()) {
-                warn!(error = ?err, "failed to set last_change_seen_at");
-            }
-            writer.apply_watcher_event(event)
-        })
+    stream.inspect_ok(move |event| {
+        if let Err(err) = last_change_seen_at.send(Instant::now()) {
+            warn!(error = ?err, "failed to set last_change_seen_at");
+        }
+        writer.apply_watcher_event(event)
+    })
 }
 
 /// A reflector fetches kubernetes objects based on filtering criteria.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29,7 +29,7 @@ use policy_evaluator::{
 };
 
 use crate::common::{build_policy_evaluator, fetch_policy, load_request_data};
-use crate::k8s_mock::{reflector_error_scenario, rego_scenario, wapc_and_wasi_scenario};
+use crate::k8s_mock::{rego_scenario, wapc_and_wasi_scenario};
 
 #[rstest]
 #[case::wapc(
@@ -218,43 +218,31 @@ async fn test_policy_evaluator(
     PolicyExecutionMode::Wasi,
     "ghcr.io/kubewarden/tests/go-wasi-context-aware-test-policy:latest",
     "app_deployment.json",
-    true,
     wapc_and_wasi_scenario
 )]
 #[case::wapc(
     PolicyExecutionMode::KubewardenWapc,
     "ghcr.io/kubewarden/tests/context-aware-test-policy:v0.1.0",
     "app_deployment.json",
-    true,
     wapc_and_wasi_scenario
 )]
 #[case::opa(
     PolicyExecutionMode::Opa,
     "ghcr.io/kubewarden/tests/context-aware-test-opa-policy:v0.1.0",
     "app_deployment.json",
-    true,
     rego_scenario
 )]
 #[case::gatekeeper(
     PolicyExecutionMode::OpaGatekeeper,
     "ghcr.io/kubewarden/tests/context-aware-test-gatekeeper-policy:v0.1.0",
     "app_deployment.json",
-    true,
     rego_scenario
-)]
-#[case::error(
-    PolicyExecutionMode::Wasi,
-    "ghcr.io/kubewarden/tests/go-wasi-context-aware-test-policy:latest",
-    "app_deployment.json",
-    false,
-    reflector_error_scenario
 )]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_runtime_context_aware<F, Fut>(
     #[case] execution_mode: PolicyExecutionMode,
     #[case] policy_uri: &str,
     #[case] request_file_path: &str,
-    #[case] allowed: bool,
     #[case] scenario: F,
 ) where
     F: FnOnce(Handle<Request<Body>, Response<Body>>) -> Fut,
@@ -315,14 +303,8 @@ async fn test_runtime_context_aware<F, Fut>(
             &PolicySettings::default(),
         );
 
-        assert_eq!(
-            allowed, admission_response.allowed,
-            "unexpexcted admission response, expecting allowed: {}, got: {:?}",
-            allowed, admission_response
-        );
-    })
-    .await
-    .unwrap();
+        assert!(admission_response.allowed, "the admission request should have been accepted, it has been rejected with this details: {:?}", admission_response);
+    }).await.unwrap();
 
     callback_handler_shutdown_channel_tx
         .send(())

--- a/tests/k8s_mock/mod.rs
+++ b/tests/k8s_mock/mod.rs
@@ -135,29 +135,6 @@ pub(crate) async fn rego_scenario(handle: Handle<Request<Body>, Response<Body>>)
     });
 }
 
-pub(crate) async fn reflector_error_scenario(handle: Handle<Request<Body>, Response<Body>>) {
-    tokio::spawn(async move {
-        let mut handle = handle;
-        loop {
-            let (request, send) = handle.next_request().await.expect("service not called");
-            match request.uri().path() {
-                "/api/v1" => {
-                    send_response(send, fixtures::v1_resource_list());
-                }
-
-                "/apis/apps/v1" => {
-                    send_response(send, fixtures::apps_v1_resource_list());
-                }
-                _ => {
-                    send.send_response(
-                        Response::builder().status(500).body(Body::empty()).unwrap(),
-                    );
-                }
-            }
-        }
-    });
-}
-
 fn send_response<T: Serialize>(send: SendResponse<Response<Body>>, response: T) {
     let response = serde_json::to_vec(&response).unwrap();
     send.send_response(Response::builder().body(Body::from(response)).unwrap());


### PR DESCRIPTION
## Description

Fix: #498 

This PR reverts breaking the watcher stream if the Initial list cannot be fetched (#490).
We are not reverting the entire PR because we want to keep some work on the integration tests that is still valuable.
This was causing long response times when a policy was initializing a reflect that was never started before, causing the timeout protection to kill the policy.

In the future we could consider moving away from the lazy initialization and starting the reflectors when the policy server start as proposed in [this rfc](https://github.com/kubewarden/rfc/blob/main/rfc/0019-reflectors-database-cache.md#sqlite-database-store).

