### PR TITLE
chore(deps): update wapc and wasmtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,17 +47,21 @@ tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = { version = "2.2", features = ["serde"] }
 validator = { version = "0.18", features = ["derive"] }
-wapc = "1.1"
+#wapc = "1.1"
+wapc = { git = "https://github.com/wapc/wapc-rs.git", tag = "wasmtime-provider-v1.17.0" }
 wasi-common = { workspace = true }
-wasmparser = "0.207"
+wasmparser = "0.208"
 wasmtime = { workspace = true }
-wasmtime-provider = { version = "1.16", features = ["cache"] }
+# wasmtime-provider = { version = "1.16", features = ["cache"] }
+wasmtime-provider = { git = "https://github.com/wapc/wapc-rs.git", tag = "wasmtime-provider-v1.17.0", features = [
+  "cache",
+] }
 wasmtime-wasi = { workspace = true }
 
 [workspace.dependencies]
-wasi-common = "19.0"
-wasmtime = "19.0"
-wasmtime-wasi = "19.0"
+wasi-common = "20.0"
+wasmtime = "20.0"
+wasmtime-wasi = "20.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0"


### PR DESCRIPTION
Update wasmtime and wapc-wasmtime to latest version.

Some notes:

- wasmtime version is constrained by wapc-wasmtime
- wapc-wasmtime is not using the latest stable release of wasmtime, because this just came out. I've made a PR to bump that, in the meantime we should just upgrade
- we cannot consume wapc-wasmtime from crates.io. We (wapc maintainers) lost access to it. Only a former maintainer has access to it. We're working to solve the issue. In the meantime we have to consume this dependency by using the git tag.
