### PR TITLE
build(deps): use kube-rs reduce buffering rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ email_address = { version = "0.2.4", features = ["serde"] }
 itertools = "0.13"
 json-patch = "2.0"
 k8s-openapi = { version = "0.22.0", default-features = false }
-kube = { version = "0.91.0", default-features = false, features = [
+# TODO: revert to upstream kube once this is merged: https://github.com/kube-rs/kube/pull/1494
+kube = { git = "https://github.com/fabriziosestito/kube", rev = "f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8", default-features = false, features = [
   "client",
   "rustls-tls",
   "runtime",


### PR DESCRIPTION
## Description

Switches to a patched revision of kube-rs (forked) that includes the stream buffering fix.
See https://github.com/kube-rs/kube/pull/1494 and https://github.com/kube-rs/kube/issues/1487

This is needed since the PR was not yet merged and we need to release v1.13.0-rc1
