### PR TITLE
fix(deps): fix kube-rs fork dependency 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.17.3"
+version = "0.17.4"
 
 [workspace]
 members = ["crates/burrego"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ itertools = "0.13"
 json-patch = "2.0"
 k8s-openapi = { version = "0.22.0", default-features = false }
 # TODO: revert to upstream kube once this is merged: https://github.com/kube-rs/kube/pull/1494
-kube = { git = "https://github.com/fabriziosestito/kube", rev = "f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8", default-features = false, features = [
+kube = { git = "https://github.com/fabriziosestito/kube", branch = "fix/reduce-buffering-between-watcher-and-store", default-features = false, features = [
   "client",
   "rustls-tls",
   "runtime",


### PR DESCRIPTION
## Description

Fixes `kube-rs` dependency (fork) that was pointing to a rev that does not exist anymore.

Bumps Cargo.toml to v0.17.4
