### PR TITLE
feat: get OCI image manifest and configuration.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ picky = { version = "7.0.0-rc.8", default-features = false, features = [
   "chrono_conversion",
   "x509",
 ] }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.8.6" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.8.7" }
 semver = { version = "1.0.22", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/callback_handler.rs
+++ b/src/callback_handler.rs
@@ -107,6 +107,11 @@ impl CallbackHandler {
                         oci::get_oci_manifest_cached(&oci_client, &image)
                     });
                 }
+                CallbackRequestType::OciManifestAndConfig { image } => {
+                    handle_callback!(req, image, "Image manifest computed", {
+                        oci::get_oci_manifest_and_config_cached(&oci_client, &image)
+                    });
+                }
                 CallbackRequestType::SigstorePubKeyVerify {
                     image,
                     pub_keys,

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -42,6 +42,13 @@ pub enum CallbackRequestType {
         image: String,
     },
 
+    /// Require the OCI object manifest and digest returned by the registry (be it an image or anything else
+    /// that can be stored into an OCI registry) and the config used to run the container
+    OciManifestAndConfig {
+        /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+        image: String,
+    },
+
     /// Require the verification of the manifest digest of an OCI object (be
     /// it an image or anything else that can be stored into an OCI registry)
     /// to be signed by Sigstore, using public keys mode


### PR DESCRIPTION
## Description

Adds a new host capability to allow guest to request an OCI image manifest, its digest and configuration.

Fix #518 

## Test

```shell
make test
```

