### PR TITLE
fix: missing callback for new capability.

### DIFF
--- a/src/runtimes/callback.rs
+++ b/src/runtimes/callback.rs
@@ -125,6 +125,29 @@ pub(crate) fn host_callback(
                         eval_ctx,
                     )
                 }
+                "v1/oci_manifest_config" => {
+                    let image: String = serde_json::from_slice(payload.to_vec().as_ref())?;
+                    debug!(
+                        eval_ctx.policy_id,
+                        binding,
+                        operation,
+                        image = image.as_str(),
+                        "Sending request via callback channel"
+                    );
+                    let (tx, rx) = oneshot::channel::<Result<CallbackResponse>>();
+                    let req = CallbackRequest {
+                        request: CallbackRequestType::OciManifestAndConfig { image },
+                        response_channel: tx,
+                    };
+                    send_request_and_wait_for_response(
+                        &eval_ctx.policy_id,
+                        binding,
+                        operation,
+                        req,
+                        rx,
+                        eval_ctx,
+                    )
+                }
                 _ => {
                     error!("unknown operation: {}", operation);
                     Err(format!("unknown operation: {operation}").into())


### PR DESCRIPTION
## Description

The policy-evaluator is missing the mapping of the callback to the recent added capability to get container image manifest and config. This commit fix that adding the missing match arm in the callbacks.rs file.

Related to https://github.com/kubewarden/kubewarden-controller/issues/749

