### PR TITLE
chore: bump version v0.18.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.18.2"
+version = "0.18.3"
 
 [workspace]
 members = ["crates/burrego"]


### PR DESCRIPTION
## Description

Updates the policy-evaluator to v0.18.3 version.