### PR TITLE
chore(deps): update dependencies and prepare for tagging new release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.19.1"
+version = "0.19.2"
 
 [workspace]
 members = ["crates/burrego"]
@@ -47,11 +47,11 @@ tokio = { version = "^1", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = { version = "2.2", features = ["serde"] }
 validator = { version = "0.18", features = ["derive"] }
-wapc = "1.1"
+wapc = "2.0"
 wasi-common = { workspace = true }
 wasmparser = "0.217"
 wasmtime = { workspace = true }
-wasmtime-provider = { version = "1.21.0", features = ["cache"] }
+wasmtime-provider = { version = "2.0.0", features = ["cache"] }
 wasmtime-wasi = { workspace = true }
 
 [workspace.dependencies]
@@ -65,10 +65,10 @@ test-log = "0.2.15"
 k8s-openapi = { version = "0.23.0", default-features = false, features = [
   "v1_30",
 ] }
-rstest = "0.22"
-serial_test = "3.0"
+rstest = "0.23"
+serial_test = "3.1"
 test-context = "0.3"
-tempfile = "3.8.1"
+tempfile = "3.13"
 tower-test = "0.4"
 hyper = { version = "1.2.0" }
 # This is required to have reqwest built using the `rustls-tls-native-roots`


### PR DESCRIPTION
Bump wapc-related crates and some developer crates.

Supersedes:

- https://github.com/kubewarden/policy-evaluator/pull/562
- https://github.com/kubewarden/policy-evaluator/pull/563
