### PR TITLE
fix: return digest as plain string instead of a json string 

### DIFF
--- a/src/callback_handler/oci.rs
+++ b/src/callback_handler/oci.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use cached::proc_macro::cached;
 use kubewarden_policy_sdk::host_capabilities::oci::ManifestDigestResponse;
 use policy_fetcher::{
@@ -41,8 +41,8 @@ impl Client {
             .registry
             .manifest_digest(&image_with_proto, self.sources.as_ref())
             .await?;
-        serde_json::to_string(&image_digest)
-            .map_err(|e| anyhow!("Cannot serialize response to json: {}", e))
+
+        Ok(image_digest)
     }
 
     pub async fn manifest(&self, image: &str) -> Result<OciManifest> {

--- a/src/runtimes/rego/runtime.rs
+++ b/src/runtimes/rego/runtime.rs
@@ -15,7 +15,7 @@ use crate::{
 
 pub(crate) struct Runtime<'a>(pub(crate) &'a mut Stack);
 
-impl<'a> Runtime<'a> {
+impl Runtime<'_> {
     pub fn validate(
         &mut self,
         settings: &PolicySettings,

--- a/src/runtimes/wapc/runtime.rs
+++ b/src/runtimes/wapc/runtime.rs
@@ -19,7 +19,7 @@ pub(crate) struct Runtime<'a>(pub(crate) &'a mut WapcStack);
 /// to look for this text
 const WAPC_EPOCH_INTERRUPTION_ERR_MSG: &str = "guest code interrupted, execution deadline exceeded";
 
-impl<'a> Runtime<'a> {
+impl Runtime<'_> {
     pub fn validate(
         &mut self,
         settings: &PolicySettings,

--- a/src/runtimes/wasi_cli/runtime.rs
+++ b/src/runtimes/wasi_cli/runtime.rs
@@ -9,7 +9,7 @@ use crate::runtimes::wasi_cli::stack::{RunResult, Stack};
 
 pub(crate) struct Runtime<'a>(pub(crate) &'a Stack);
 
-impl<'a> Runtime<'a> {
+impl Runtime<'_> {
     pub fn validate(
         &self,
         settings: &PolicySettings,


### PR DESCRIPTION
## Description

The `OciManifestDigest` response returns the digest as a JSON string since it was erroneously encoded to JSON in the callback handler.
This PR removes the extra encoding returning a plain string.
## Test

Test was missing, added

