### PR TITLE
chore: v0.19.7 version bump.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.19.6"
+version = "0.19.7"
 
 [workspace]
 members = ["crates/burrego"]


### PR DESCRIPTION
## Description

Bumps crate to version 0.19.7.

