### PR TITLE
fix: tinygo 0.35.0 policies exit at startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.19.7"
+version = "0.19.8"
 
 [workspace]
 members = ["crates/burrego"]
@@ -52,7 +52,7 @@ wapc = "2.1"
 wasi-common = { workspace = true }
 wasmparser = "0.223"
 wasmtime = { workspace = true }
-wasmtime-provider = { version = "2.3.0", features = ["cache"] }
+wasmtime-provider = { version = "2.3.1", features = ["cache"] }
 wasmtime-wasi = { workspace = true }
 
 [workspace.dependencies]


### PR DESCRIPTION
The policies built with tinygo >= 0.35.0 failed to run.

The issue was inside of the wasmtime-provider of the wapc project.

This commit updates to a version of the crate that fixes the problem.
