### PR TITLE
build(deps): group wasmtime crates updates together.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "github>kubewarden/github-actions//renovate-config/default"
+  ],
+    "packageRules": [
+    {
+      "description": "Update all wasmtime packages together",
+      "matchPackageNames": ["wasmtime-wasi", "wasmtime", "wasi-common"]
+    }
   ]
 }


### PR DESCRIPTION
## Description

Updates the renovate bot configuration to bump wasmtime-wasi, wasmtime and wasi-common crates versions together.

