### PR TITLE
fix: address broken sigstore's TUF repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.19.8"
+version = "0.19.9"
 
 [workspace]
 members = ["crates/burrego"]
@@ -36,7 +36,7 @@ picky = { version = "7.0.0-rc.8", default-features = false, features = [
   "chrono_conversion",
   "x509",
 ] }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.8.13" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.8.14" }
 semver = { version = "1.0.22", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
The contents of Sigstore's TUF repository have been recently changed and, due to a mistake, the sigstore-rs was broken.

This commit consumes a forked version of sigstore-rs, which consumes a forked version of the tough crate.

This is required to fix https://github.com/sigstore/sigstore-rs/issues/429 until upstream changes the contents of TUF's repository.
