### PR TITLE
chore: bump version to v0.19.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.19.9"
+version = "0.19.10"
 
 [workspace]
 members = ["crates/burrego"]


### PR DESCRIPTION
bump version to v0.19.10 
