### PR TITLE
chore(deps): update sigstore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,14 @@ kube = { version = "0.98.0", default-features = false, features = [
   "rustls-tls",
   "runtime",
 ] }
-kubewarden-policy-sdk = "0.12.0"
+kubewarden-policy-sdk = "0.13.0"
 lazy_static = "1.4"
 mail-parser = { version = "0.10.0", features = ["serde"] }
 picky = { version = "7.0.0-rc.8", default-features = false, features = [
   "chrono_conversion",
   "x509",
 ] }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.8.14" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.9.0" }
 semver = { version = "1.0.22", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/callback_handler/sigstore_verification.rs
+++ b/src/callback_handler/sigstore_verification.rs
@@ -14,7 +14,7 @@ use sigstore::cosign::verification_constraint::{
     AnnotationVerifier, CertificateVerifier, VerificationConstraintVec,
 };
 use sigstore::registry::{Certificate, CertificateEncoding};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::warn;
@@ -71,7 +71,7 @@ impl Client {
         &mut self,
         image: String,
         pub_keys: Vec<String>,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Result<VerificationResponse> {
         if pub_keys.is_empty() {
             return Err(anyhow!("Must provide at least one pub key"));
@@ -104,7 +104,7 @@ impl Client {
         &mut self,
         image: String,
         keyless: Vec<KeylessInfo>,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Result<VerificationResponse> {
         if keyless.is_empty() {
             return Err(anyhow!("Must provide keyless info"));
@@ -139,7 +139,7 @@ impl Client {
         &mut self,
         image: String,
         keyless_prefix: Vec<KeylessPrefixInfo>,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Result<VerificationResponse> {
         if keyless_prefix.is_empty() {
             return Err(anyhow!("Must provide keyless info"));
@@ -176,7 +176,7 @@ impl Client {
         image: String,
         owner: String,
         repo: Option<String>,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Result<VerificationResponse> {
         if owner.is_empty() {
             return Err(anyhow!("Must provide owner info"));
@@ -211,7 +211,7 @@ impl Client {
         certificate: &[u8],
         certificate_chain: Option<&[Vec<u8>]>,
         require_rekor_bundle: bool,
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     ) -> Result<VerificationResponse> {
         let (source_image_digest, trusted_layers) =
             fetch_sigstore_remote_data(&self.cosign_client, image).await?;
@@ -267,7 +267,7 @@ pub(crate) async fn get_sigstore_pub_key_verification_cached(
     client: &mut Client,
     image: String,
     pub_keys: Vec<String>,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
     client
         .verify_public_key(image, pub_keys, annotations)
@@ -294,7 +294,7 @@ pub(crate) async fn get_sigstore_keyless_verification_cached(
     client: &mut Client,
     image: String,
     keyless: Vec<KeylessInfo>,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
     client
         .verify_keyless(image, keyless, annotations)
@@ -321,7 +321,7 @@ pub(crate) async fn get_sigstore_keyless_prefix_verification_cached(
     client: &mut Client,
     image: String,
     keyless_prefix: Vec<KeylessPrefixInfo>,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
     client
         .verify_keyless_prefix(image, keyless_prefix, annotations)
@@ -349,7 +349,7 @@ pub(crate) async fn get_sigstore_github_actions_verification_cached(
     image: String,
     owner: String,
     repo: Option<String>,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
     client
         .verify_github_actions(image, owner, repo, annotations)
@@ -362,7 +362,7 @@ fn get_sigstore_certificate_verification_cache_key(
     certificate: &[u8],
     certificate_chain: Option<&[Vec<u8>]>,
     require_rekor_bundle: bool,
-    annotations: Option<&HashMap<String, String>>,
+    annotations: Option<&BTreeMap<String, String>>,
 ) -> String {
     let mut hasher = Sha256::new();
 
@@ -406,7 +406,7 @@ pub(crate) async fn get_sigstore_certificate_verification_cached(
     certificate: &[u8],
     certificate_chain: Option<&[Vec<u8>]>,
     require_rekor_bundle: bool,
-    annotations: Option<HashMap<String, String>>,
+    annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
     client
         .verify_certificate(

--- a/src/callback_requests.rs
+++ b/src/callback_requests.rs
@@ -4,7 +4,7 @@ use kubewarden_policy_sdk::host_capabilities::{
     SigstoreVerificationInputV1, SigstoreVerificationInputV2,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use tokio::{sync::oneshot, time::Instant};
 
 /// Holds the response to a waPC evaluation request
@@ -58,7 +58,7 @@ pub enum CallbackRequestType {
         /// List of PEM encoded keys that must have been used to sign the OCI object
         pub_keys: Vec<String>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Require the verification of the manifest digest of an OCI object to be
@@ -69,7 +69,7 @@ pub enum CallbackRequestType {
         /// List of keyless signatures that must be found
         keyless: Vec<KeylessInfo>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Require the verification of the manifest digest of an OCI object to be
@@ -81,7 +81,7 @@ pub enum CallbackRequestType {
         /// List of keyless signatures that must be found
         keyless_prefix: Vec<KeylessPrefixInfo>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Require the verification of the manifest digest of an OCI object to be
@@ -94,7 +94,7 @@ pub enum CallbackRequestType {
         /// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
         repo: Option<String>,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Require the verification of the manifest digest of an OCI object
@@ -116,7 +116,7 @@ pub enum CallbackRequestType {
         /// verification process.
         require_rekor_bundle: bool,
         /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
-        annotations: Option<HashMap<String, String>>,
+        annotations: Option<BTreeMap<String, String>>,
     },
 
     /// Lookup the addresses for a given hostname via DNS


### PR DESCRIPTION
Upgrade to latest verison of sigstore by consuming latest releaes of policy-evaluator.

We must use latest version of the Kubewarden SDK too to have the code compile.
