### PR TITLE
refactor annotations

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,5 @@
+[formatting]
+align_entries  = true
+reorder_arrays = true
+reorder_keys   = true
+sort_keys      = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = [
+  "Fabrizio Sestito <fabrizio.sestito@suse.com>",
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",
   "Víctor Cuadrado Juan <vcuadradojuan@suse.com>",
-  "Fabrizio Sestito <fabrizio.sestito@suse.com>",
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.19.11"
+version = "0.20.0"
 
 [workspace]
 members = ["crates/burrego"]
@@ -19,15 +19,15 @@ burrego = { path = "crates/burrego" }
 cached = { version = "0.54", features = ["async_tokio_rt_multi_thread"] }
 chrono = { version = "0.4.38", default-features = false }
 dns-lookup = "2.0"
-futures = "0.3"
 email_address = { version = "0.2.4", features = ["serde"] }
+futures = "0.3"
 itertools = "0.14"
 json-patch = "3.0"
 k8s-openapi = { version = "0.24.0", default-features = false }
 kube = { version = "0.98.0", default-features = false, features = [
   "client",
-  "rustls-tls",
   "runtime",
+  "rustls-tls",
 ] }
 kubewarden-policy-sdk = "0.13.0"
 lazy_static = "1.4"
@@ -36,7 +36,7 @@ picky = { version = "7.0.0-rc.8", default-features = false, features = [
   "chrono_conversion",
   "x509",
 ] }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.9.0" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.10.0" }
 semver = { version = "1.0.22", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -56,22 +56,22 @@ wasmtime-provider = { version = "2.4.0", features = ["cache"] }
 wasmtime-wasi = { workspace = true }
 
 [workspace.dependencies]
-wasi-common = "29.0"
-wasmtime = "29.0"
+wasi-common   = "29.0"
+wasmtime      = "29.0"
 wasmtime-wasi = "29.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0"
-test-log = "0.2.15"
+hyper = { version = "1.2.0" }
 k8s-openapi = { version = "0.24.0", default-features = false, features = [
   "v1_30",
 ] }
 rstest = "0.24"
 serial_test = "3.1"
-test-context = "0.4"
 tempfile = "3.13"
+test-context = "0.4"
+test-log = "0.2.15"
 tower-test = "0.4"
-hyper = { version = "1.2.0" }
 # This is required to have reqwest built using the `rustls-tls-native-roots`
 # feature across all the transitive dependencies of policy-fetcher
 # This is required to have the integration tests use the system certificates instead of the

--- a/src/policy_artifacthub.rs
+++ b/src/policy_artifacthub.rs
@@ -2,7 +2,7 @@ use email_address::*;
 use policy_fetcher::oci_client::{ParseError, Reference};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::str::FromStr;
 use time::OffsetDateTime;
@@ -211,7 +211,7 @@ impl ArtifactHubPkg {
     }
 }
 
-fn parse_name(metadata_annots: &HashMap<String, String>) -> Result<String> {
+fn parse_name(metadata_annots: &BTreeMap<String, String>) -> Result<String> {
     metadata_annots
         .get(KUBEWARDEN_ANNOTATION_POLICY_TITLE)
         .ok_or_else(|| {
@@ -220,7 +220,7 @@ fn parse_name(metadata_annots: &HashMap<String, String>) -> Result<String> {
         .cloned()
 }
 
-fn parse_display_name(metadata_annots: &HashMap<String, String>) -> Result<String> {
+fn parse_display_name(metadata_annots: &BTreeMap<String, String>) -> Result<String> {
     metadata_annots
         .get(KUBEWARDEN_ANNOTATION_ARTIFACTHUB_DISPLAYNAME)
         .ok_or_else(|| {
@@ -231,7 +231,7 @@ fn parse_display_name(metadata_annots: &HashMap<String, String>) -> Result<Strin
         .cloned()
 }
 
-fn parse_description(metadata_annots: &HashMap<String, String>) -> Result<String> {
+fn parse_description(metadata_annots: &BTreeMap<String, String>) -> Result<String> {
     metadata_annots
         .get(KUBEWARDEN_ANNOTATION_POLICY_DESCRIPTION)
         .ok_or_else(|| {
@@ -242,7 +242,7 @@ fn parse_description(metadata_annots: &HashMap<String, String>) -> Result<String
         .cloned()
 }
 
-fn parse_home_url(metadata_annots: &HashMap<String, String>) -> Result<Option<Url>> {
+fn parse_home_url(metadata_annots: &BTreeMap<String, String>) -> Result<Option<Url>> {
     match metadata_annots.get(KUBEWARDEN_ANNOTATION_POLICY_URL) {
         Some(s) => {
             let url = Url::parse(s).map_err(|e| ArtifactHubError::MalformedURL {
@@ -256,7 +256,7 @@ fn parse_home_url(metadata_annots: &HashMap<String, String>) -> Result<Option<Ur
 }
 
 fn parse_oci_url(
-    metadata_annots: &HashMap<String, String>,
+    metadata_annots: &BTreeMap<String, String>,
     version: &Version,
 ) -> Result<Option<String>> {
     match metadata_annots.get(KUBEWARDEN_ANNOTATION_POLICY_OCIURL) {
@@ -275,7 +275,7 @@ fn parse_oci_url(
 }
 
 fn parse_containers_images(
-    metadata_annots: &HashMap<String, String>,
+    metadata_annots: &BTreeMap<String, String>,
     version: &Version,
 ) -> Result<Option<Vec<ContainerImage>>> {
     match metadata_annots.get(KUBEWARDEN_ANNOTATION_POLICY_OCIURL) {
@@ -301,7 +301,7 @@ fn parse_containers_images(
 
 /// parses the value of annotation KUBEWARDEN_ANNOTATION_ARTIFACTHUB_KEYWORDS of
 /// csv of keywords into a vector of keywords, making sure is well formed
-fn parse_keywords(metadata_annots: &HashMap<String, String>) -> Result<Option<Vec<String>>> {
+fn parse_keywords(metadata_annots: &BTreeMap<String, String>) -> Result<Option<Vec<String>>> {
     match metadata_annots.get(KUBEWARDEN_ANNOTATION_ARTIFACTHUB_KEYWORDS) {
         Some(s) => {
             let csv = s
@@ -325,7 +325,7 @@ fn parse_keywords(metadata_annots: &HashMap<String, String>) -> Result<Option<Ve
 /// parses the value of annotation KUBEWARDEN_ANNOTATION_POLICY_SOURCE
 /// into a vector of Link, making sure is well formed
 fn parse_links(
-    metadata_annots: &HashMap<String, String>,
+    metadata_annots: &BTreeMap<String, String>,
     version: &Version,
 ) -> Result<Option<Vec<Link>>> {
     match metadata_annots.get(KUBEWARDEN_ANNOTATION_POLICY_SOURCE) {
@@ -385,7 +385,9 @@ kwctl scaffold manifest -t ClusterAdmissionPolicy registry://{oci_url}
 
 // parses the value of annotation KUBEWARDEN_ANNOTATION_POLICY_AUTHOR into a
 // vector of maintainers, making sure the csv input and emails are well formed
-fn parse_maintainers(metadata_annots: &HashMap<String, String>) -> Result<Option<Vec<Maintainer>>> {
+fn parse_maintainers(
+    metadata_annots: &BTreeMap<String, String>,
+) -> Result<Option<Vec<Maintainer>>> {
     match metadata_annots.get(KUBEWARDEN_ANNOTATION_POLICY_AUTHOR) {
         Some(s) => {
             // name-addr https://www.rfc-editor.org/rfc/rfc5322#section-3.4
@@ -422,7 +424,7 @@ fn parse_maintainers(metadata_annots: &HashMap<String, String>) -> Result<Option
 }
 
 fn parse_annotations(
-    metadata_annots: &HashMap<String, String>,
+    metadata_annots: &BTreeMap<String, String>,
     metadata: &Metadata,
     questions: Option<&str>,
 ) -> Result<BTreeMap<String, String>> {
@@ -477,13 +479,13 @@ mod tests {
     use crate::policy_metadata::{ContextAwareResource, PolicyType};
     use assert_json_diff::assert_json_eq;
     use serde_json::json;
-    use std::collections::{BTreeSet, HashMap};
+    use std::collections::{BTreeMap, BTreeSet};
 
     fn mock_metadata_with_minimum_required() -> Metadata {
         Metadata {
             protocol_version: None,
             rules: vec![],
-            annotations: Some(HashMap::from([
+            annotations: Some(BTreeMap::from([
                 (
                     String::from(KUBEWARDEN_ANNOTATION_POLICY_TITLE),
                     String::from("verify-image-signatures"),
@@ -524,7 +526,7 @@ mod tests {
         Metadata {
             protocol_version: None,
             rules: vec![],
-            annotations: Some(HashMap::from([
+            annotations: Some(BTreeMap::from([
                 (
                     String::from(KUBEWARDEN_ANNOTATION_POLICY_TITLE),
                     String::from("verify-image-signatures"),
@@ -592,7 +594,7 @@ mod tests {
 
         // check annotations empty
         let metadata = Metadata {
-            annotations: Some(HashMap::from([])),
+            annotations: Some(BTreeMap::from([])),
             ..Default::default()
         };
         let arthub =
@@ -613,7 +615,7 @@ mod tests {
 
         // check questions is some and not empty
         let metadata = Metadata {
-            annotations: Some(HashMap::from([(String::from("foo"), String::from("bar"))])),
+            annotations: Some(BTreeMap::from([(String::from("foo"), String::from("bar"))])),
             ..Default::default()
         };
         let arthub =
@@ -625,15 +627,15 @@ mod tests {
 
     #[test]
     fn check_parse_keywords() -> Result<()> {
-        let keywords_annot = HashMap::from([(
+        let keywords_annot = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_ARTIFACTHUB_KEYWORDS),
             String::from(" foo,bar, faz fiz, baz"),
         )]);
-        let keywords_annot_empty = HashMap::from([(
+        let keywords_annot_empty = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_ARTIFACTHUB_KEYWORDS),
             String::from(""),
         )]);
-        let keywords_annot_commas = HashMap::from([(
+        let keywords_annot_commas = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_ARTIFACTHUB_KEYWORDS),
             String::from("foo,,bar"),
         )]);
@@ -665,15 +667,15 @@ mod tests {
     #[test]
     fn check_parse_links() -> Result<()> {
         let semver_version = Version::parse("0.2.1").unwrap();
-        let source_annot = HashMap::from([(
+        let source_annot = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_POLICY_SOURCE),
             String::from("https://github.com/repo"),
         )]);
-        let source_annot_not_github = HashMap::from([(
+        let source_annot_not_github = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_POLICY_SOURCE),
             String::from("https://notgithub.com/repo"),
         )]);
-        let source_annot_badurl = HashMap::from([(
+        let source_annot_badurl = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_POLICY_SOURCE),
             String::from("@&*foo"),
         )]);
@@ -709,23 +711,23 @@ mod tests {
 
     #[test]
     fn check_parse_maintainers() -> Result<()> {
-        let author_annot = HashMap::from([(
+        let author_annot = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_POLICY_AUTHOR),
             String::from("Tux Tuxedo <tux@example.com>, Pidgin <pidgin@example.com>"),
         )]);
-        let author_annot_empty = HashMap::from([(
+        let author_annot_empty = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_POLICY_AUTHOR),
             String::from(""),
         )]);
-        let author_annot_commas = HashMap::from([(
+        let author_annot_commas = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_POLICY_AUTHOR),
             String::from("Foo <foo@example.com>,,Bar <bar@example.com>"),
         )]);
-        let author_annot_nameemail = HashMap::from([(
+        let author_annot_nameemail = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_POLICY_AUTHOR),
             String::from("Foo missing@chevrons.com, Bar <bar@example.com>"),
         )]);
-        let author_annot_bademail = HashMap::from([(
+        let author_annot_bademail = BTreeMap::from([(
             String::from(KUBEWARDEN_ANNOTATION_POLICY_AUTHOR),
             String::from("Bar <#$%#$%>"),
         )]);
@@ -776,7 +778,7 @@ mod tests {
     #[test]
     fn artifacthubpkg_missing_required() -> Result<()> {
         let semver_version = Version::parse("0.2.1").unwrap();
-        let invalid_annotations = HashMap::from([(String::from("foo"), String::from("bar"))]);
+        let invalid_annotations = BTreeMap::from([(String::from("foo"), String::from("bar"))]);
 
         assert!(parse_name(&invalid_annotations).is_err());
         assert!(parse_display_name(&invalid_annotations).is_err());

--- a/src/policy_metadata.rs
+++ b/src/policy_metadata.rs
@@ -1,15 +1,17 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    fmt::{self, Display},
+    path::Path,
+};
+
 use k8s_openapi::api::admissionregistration::v1::NamedRuleWithOperations;
 use kubewarden_policy_sdk::metadata::ProtocolVersion;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap, HashSet};
-use std::fmt::{self, Display};
-use std::path::Path;
 use validator::{Validate, ValidationError};
 use wasmparser::{Parser, Payload};
 
-use crate::errors::MetadataError;
-use crate::policy_evaluator::PolicyExecutionMode;
+use crate::{errors::MetadataError, policy_evaluator::PolicyExecutionMode};
 
 #[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
 pub enum Operation {
@@ -191,7 +193,7 @@ pub struct Metadata {
     #[validate(nested)]
     pub rules: Vec<Rule>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<HashMap<String, String>>,
+    pub annotations: Option<BTreeMap<String, String>>,
     pub mutating: bool,
     #[serde(default = "_default_true")]
     pub background_audit: bool,
@@ -215,7 +217,7 @@ impl Default for Metadata {
         Self {
             protocol_version: None,
             rules: vec![],
-            annotations: Some(HashMap::new()),
+            annotations: Some(BTreeMap::new()),
             mutating: false,
             background_audit: true,
             execution_mode: PolicyExecutionMode::KubewardenWapc,
@@ -450,7 +452,7 @@ mod tests {
             operations: vec![Operation::Create],
         };
 
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(
             String::from("io.kubewarden.policy.author"),
             String::from("Flavio Castelli"),
@@ -504,7 +506,7 @@ mod tests {
             operations: vec![Operation::Create],
         };
 
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(
             String::from("io.kubewarden.policy.author"),
             String::from("Flavio Castelli"),
@@ -531,7 +533,7 @@ mod tests {
             operations: vec![Operation::Create],
         };
 
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(
             String::from("io.kubewarden.policy.author"),
             String::from("Flavio Castelli"),
@@ -558,7 +560,7 @@ mod tests {
             operations: vec![Operation::Create],
         };
 
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(
             String::from("io.kubewarden.policy.author"),
             String::from("Flavio Castelli"),
@@ -584,7 +586,7 @@ mod tests {
             operations: vec![Operation::Create],
         };
 
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(
             String::from("io.kubewarden.policy.author"),
             String::from("Flavio Castelli"),
@@ -610,7 +612,7 @@ mod tests {
             operations: vec![Operation::Create],
         };
 
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(
             String::from("io.kubewarden.policy.author"),
             String::from("Flavio Castelli"),
@@ -636,7 +638,7 @@ mod tests {
             operations: vec![Operation::Create],
         };
 
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(
             String::from("io.kubewarden.policy.author"),
             String::from("Flavio Castelli"),
@@ -655,7 +657,7 @@ mod tests {
 
     #[test]
     fn validate_context_aware_resource_without_api_group() {
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(
             String::from("io.kubewarden.policy.author"),
             String::from("Flavio Castelli"),
@@ -679,7 +681,7 @@ mod tests {
 
     #[test]
     fn validate_context_aware_resource_without_kind() {
-        let mut annotations: HashMap<String, String> = HashMap::new();
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
         annotations.insert(
             String::from("io.kubewarden.policy.author"),
             String::from("Flavio Castelli"),


### PR DESCRIPTION
All the annotations are now using BTreeMap instead of HashMap, this makes everything simpler when dealing with OCI annotations (which use this data structure).

This is part of the work required to implement https://github.com/kubewarden/kwctl/issues/1044

While working on this PR, I've added a taplo configuration file to the repository, this will help us to keep the Cargo.toml file nice and tidy.

