### PR TITLE
feat: introduce policy version annotation

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,7 @@
 pub const KUBEWARDEN_CUSTOM_SECTION_METADATA: &str = "io.kubewarden.metadata";
 
 pub const KUBEWARDEN_ANNOTATION_POLICY_TITLE: &str = "io.kubewarden.policy.title";
+pub const KUBEWARDEN_ANNOTATION_POLICY_VERSION: &str = "io.kubewarden.policy.version";
 pub const KUBEWARDEN_ANNOTATION_POLICY_DESCRIPTION: &str = "io.kubewarden.policy.description";
 pub const KUBEWARDEN_ANNOTATION_POLICY_AUTHOR: &str = "io.kubewarden.policy.author";
 pub const KUBEWARDEN_ANNOTATION_POLICY_URL: &str = "io.kubewarden.policy.url";


### PR DESCRIPTION
Introduce a new annotation to keep track of a policy version: `io.kubewarde.policy.version`.

This annotation is then required when scaffolding the `artifacthub-pkg.yaml` file.

Required to fix https://github.com/kubewarden/kwctl/issues/1137
