### PR TITLE
chore: bump v0.25.2 version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.25.1"
+version = "0.25.2"
 
 [workspace]
 members = ["crates/burrego"]


### PR DESCRIPTION
## Description

Updates the version of the policy-evaluator to release the k8s-openapi update.

