### PR TITLE
kwctl policy group changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ url = { version = "2.5", features = ["serde"] }
 validator = { version = "0.20", features = ["derive"] }
 wapc = "2.1"
 wasi-common = { workspace = true }
-wasmparser = "0.233"
+wasmparser = "0.234"
 wasmtime = { workspace = true }
 wasmtime-provider = { version = "2.8.0", features = ["cache"] }
 wasmtime-wasi = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-evaluator"
-version = "0.25.2"
+version = "0.26.0"
 
 [workspace]
 members = ["crates/burrego"]

--- a/src/policy_evaluator/policy_evaluator_builder.rs
+++ b/src/policy_evaluator/policy_evaluator_builder.rs
@@ -154,10 +154,6 @@ impl PolicyEvaluatorBuilder {
             return Err(InvalidUserInputError::EngineForModule);
         }
 
-        if self.execution_mode.is_none() {
-            return Err(InvalidUserInputError::ExecutionMode);
-        }
-
         Ok(())
     }
 
@@ -169,7 +165,7 @@ impl PolicyEvaluatorBuilder {
         let engine = self.build_engine()?;
         let module = self.build_module(&engine)?;
 
-        let execution_mode = self.execution_mode.unwrap();
+        let execution_mode = self.execution_mode.unwrap_or_default();
 
         let stack_pre = match execution_mode {
             PolicyExecutionMode::KubewardenWapc => {

--- a/src/policy_group_evaluator.rs
+++ b/src/policy_group_evaluator.rs
@@ -1,5 +1,11 @@
 use std::{collections::BTreeSet, fmt};
 
+use k8s_openapi::apimachinery::pkg::runtime::RawExtension;
+use kubewarden_policy_sdk::crd::policies::{
+    admission_policy_group::PolicyGroupMember,
+    cluster_admission_policy_group::PolicyGroupMemberWithContext,
+};
+
 pub mod errors;
 pub mod evaluator;
 
@@ -44,5 +50,146 @@ impl fmt::Display for PolicyGroupMemberEvaluationResult {
         }
 
         Ok(())
+    }
+}
+
+/// Converts a `kubewarden_policy_sdk::crd::RawExtension` to `PolicySettings`.
+/// If the `RawExtension` is `null`, it returns default settings.
+/// If the `RawExtension` is an object, it converts it to `PolicySettings`.
+/// If the `RawExtension` is not an object or null, it returns an error.
+fn convert_raw_extension_to_settings(
+    raw_extension: &RawExtension,
+) -> Result<PolicySettings, &'static str> {
+    match &raw_extension.0 {
+        serde_json::Value::Null => Ok(PolicySettings::default()),
+        serde_json::Value::Object(obj) => Ok(obj.to_owned()),
+        _ => Err("Invalid settings in CRD, not an object"),
+    }
+}
+
+impl TryFrom<&PolicyGroupMemberWithContext> for PolicyGroupMemberSettings {
+    type Error = &'static str;
+
+    fn try_from(member: &PolicyGroupMemberWithContext) -> Result<Self, Self::Error> {
+        let settings = convert_raw_extension_to_settings(&member.settings)?;
+        let ctx_aware_resources_allow_list = member
+            .context_aware_resources
+            .iter()
+            .map(|car| car.into())
+            .collect();
+
+        Ok(Self {
+            settings,
+            ctx_aware_resources_allow_list,
+        })
+    }
+}
+
+impl TryFrom<&PolicyGroupMember> for PolicyGroupMemberSettings {
+    type Error = &'static str;
+
+    fn try_from(member: &PolicyGroupMember) -> Result<Self, Self::Error> {
+        let settings = convert_raw_extension_to_settings(&member.settings)?;
+
+        Ok(Self {
+            settings,
+            ctx_aware_resources_allow_list: BTreeSet::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assert_json_diff::assert_json_eq;
+    use kubewarden_policy_sdk::crd::policies::common::ContextAwareResource as ContextAwareResourceSdk;
+    use rstest::rstest;
+    use serde_json::json;
+
+    #[rstest]
+    #[case::dictionrary(json!({"key1": "value1", "key2": "value2"}), true)]
+    #[case::empty_dictionrary(json!({}), true)]
+    #[case::nil(serde_json::Value::Null, true)]
+    #[case::string(json!("boom"), false)]
+    #[case::number(json!(123), false)]
+    #[case::bool(json!(true), false)]
+    fn convert_raw_extension_to_settings_conversion(
+        #[case] settings: serde_json::Value,
+        #[case] is_ok: bool,
+    ) {
+        let conversion_result = convert_raw_extension_to_settings(&RawExtension(settings.clone()));
+        assert_eq!(
+            conversion_result.is_ok(),
+            is_ok,
+            "Conversion should {}",
+            if is_ok { "succeed" } else { "fail" }
+        );
+    }
+
+    #[test]
+    fn test_convert_policy_group_member_with_context_into_policy_group_member() {
+        let settings = json!({
+            "key1": "value1",
+            "key2": "value2"
+        });
+
+        let context_aware_resources_sdk = vec![
+            ContextAwareResourceSdk {
+                api_version: "v1".to_string(),
+                kind: "Pod".to_string(),
+            },
+            ContextAwareResourceSdk {
+                api_version: "v1".to_string(),
+                kind: "Service".to_string(),
+            },
+        ];
+
+        let expected_context_aware_resources: BTreeSet<ContextAwareResource> = BTreeSet::from([
+            ContextAwareResource {
+                api_version: "v1".to_string(),
+                kind: "Pod".to_string(),
+            },
+            ContextAwareResource {
+                api_version: "v1".to_string(),
+                kind: "Service".to_string(),
+            },
+        ]);
+
+        let pgmc = PolicyGroupMemberWithContext {
+            module: "test-module.wasm".to_string(),
+            settings: RawExtension(settings.clone()),
+            context_aware_resources: context_aware_resources_sdk,
+        };
+
+        let policy_group_member_settings: PolicyGroupMemberSettings =
+            PolicyGroupMemberSettings::try_from(&pgmc).expect("Failed to convert");
+
+        assert_json_eq!(policy_group_member_settings.settings, settings);
+        assert_eq!(
+            expected_context_aware_resources,
+            policy_group_member_settings.ctx_aware_resources_allow_list
+        );
+    }
+
+    #[test]
+    fn test_convert_policy_group_member_into_policy_group_member() {
+        let settings = json!({
+            "key1": "value1",
+            "key2": "value2"
+        });
+
+        let pgm = PolicyGroupMember {
+            module: "test-module.wasm".to_string(),
+            settings: RawExtension(settings.clone()),
+        };
+
+        let policy_group_member_settings: PolicyGroupMemberSettings =
+            PolicyGroupMemberSettings::try_from(&pgm).expect("Failed to convert");
+
+        assert_json_eq!(policy_group_member_settings.settings, settings);
+        assert!(policy_group_member_settings
+            .ctx_aware_resources_allow_list
+            .is_empty(),);
     }
 }

--- a/src/policy_group_evaluator/evaluator.rs
+++ b/src/policy_group_evaluator/evaluator.rs
@@ -270,7 +270,7 @@ impl PolicyGroupEvaluator {
     ///
     /// Each policy is validated individually, and the expression is also validated.
     #[tracing::instrument]
-    pub fn validate_settings(self) -> SettingsValidationResponse {
+    pub fn validate_settings(&self) -> SettingsValidationResponse {
         let mut rhai_engine = rhai::Engine::new_raw();
 
         let mut policy_validation_errors = HashMap::new();

--- a/src/policy_group_evaluator/evaluator.rs
+++ b/src/policy_group_evaluator/evaluator.rs
@@ -492,7 +492,7 @@ mod tests {
                 .causes;
             for expected in expected_status_causes {
                 assert!(
-                    causes.iter().any(|c| *c == expected),
+                    causes.contains(&expected),
                     "could not find cause {:?}",
                     expected
                 );

--- a/src/runtimes/rego/runtime.rs
+++ b/src/runtimes/rego/runtime.rs
@@ -163,7 +163,11 @@ impl Runtime<'_> {
         let data = match ctx_data {
             KubernetesContext::Opa(ctx) => {
                 let mut data = settings.clone();
-                if data.insert("kubernetes".to_string(), json!(ctx)).is_some() {
+                if data
+                    .0
+                    .insert("kubernetes".to_string(), json!(ctx))
+                    .is_some()
+                {
                     warn!("OPA policy had user provided setting with key `kubernetes`. This value has been overwritten with the actual kubernetes context data");
                 }
                 json!(data)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use tempfile::TempDir;
+use std::path::PathBuf;
 
 use policy_evaluator::{
     evaluation_context::EvaluationContext, policy_evaluator::PolicyEvaluator,
@@ -6,10 +6,10 @@ use policy_evaluator::{
 };
 use policy_fetcher::{policy::Policy, PullDestination};
 
-pub(crate) async fn fetch_policy(policy_uri: &str, tempdir: TempDir) -> Policy {
+pub(crate) async fn fetch_policy(policy_uri: &str, tempdir: PathBuf) -> Policy {
     policy_evaluator::policy_fetcher::fetch_policy(
         policy_uri,
-        PullDestination::LocalFile(tempdir.into_path()),
+        PullDestination::LocalFile(tempdir),
         None,
     )
     .await

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -192,6 +192,7 @@ async fn test_policy_evaluator(
     #[case] code: Option<u16>,
     #[case] mutating: bool,
 ) {
+    let settings = PolicySettings::try_from(&settings).expect("cannot convert settings");
     let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
     let policy = fetch_policy(policy_uri, tempdir.path().to_owned()).await;
 
@@ -214,9 +215,6 @@ async fn test_policy_evaluator(
         ValidateRequest::AdmissionRequest(Box::new(admission_request))
     };
 
-    let serde_json::Value::Object(settings) = settings else {
-        panic!("settings must be an object")
-    };
     let settings_validation_response = policy_evaluator.validate_settings(&settings);
     assert!(settings_validation_response.valid);
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -193,7 +193,7 @@ async fn test_policy_evaluator(
     #[case] mutating: bool,
 ) {
     let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-    let policy = fetch_policy(policy_uri, tempdir).await;
+    let policy = fetch_policy(policy_uri, tempdir.path().to_owned()).await;
 
     let eval_ctx = EvaluationContext {
         policy_id: "test".to_owned(),
@@ -282,7 +282,7 @@ async fn test_runtime_context_aware<F, Fut>(
     use kube::client::Body;
 
     let tempdir = tempfile::TempDir::new().expect("cannot create tempdir");
-    let policy = fetch_policy(policy_uri, tempdir).await;
+    let policy = fetch_policy(policy_uri, tempdir.path().to_owned()).await;
 
     let (mocksvc, handle) = tower_test::mock::pair::<Request<Body>, Response<Body>>();
     let client = Client::new(mocksvc, "default");


### PR DESCRIPTION
These are some changes required to implement the `kwctl run <group>` feature (see https://github.com/kubewarden/kwctl/issues/967).

Once merged, a new version of policy-evaluator should be tagged

- **refactor(test): do not use deprecated code**
- **refactor: address linter warning**
- **feat: implement `TryInto` to convert SDKs ojects**
