### PR TITLE
chore(deps): update wasmtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,13 +53,13 @@ wapc = "2.1"
 wasi-common = { workspace = true }
 wasmparser = "0.235"
 wasmtime = { workspace = true }
-wasmtime-provider = { version = "2.8.0", features = ["cache"] }
+wasmtime-provider = { version = "2.9.0", features = ["cache"] }
 wasmtime-wasi = { workspace = true }
 
 [workspace.dependencies]
-wasi-common   = "33.0"
-wasmtime      = "33.0"
-wasmtime-wasi = "33.0"
+wasi-common   = "34.0"
+wasmtime      = "34.0"
+wasmtime-wasi = "34.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0"

--- a/src/runtimes/wasi_cli/stack_pre.rs
+++ b/src/runtimes/wasi_cli/stack_pre.rs
@@ -117,7 +117,7 @@ fn add_host_call_to_linker(linker: &mut wasmtime::Linker<Context>) -> Result<()>
     Ok(())
 }
 
-fn get_vec_from_memory<'a, T: 'a>(
+fn get_vec_from_memory<'a, T: 'static>(
     store: impl Into<StoreContext<'a, T>>,
     mem: Memory,
     ptr: i32,


### PR DESCRIPTION
Update to latest stable version of `wasmtime`, also update `wasmtime-provider`.

Fix some issues caused by API changes.

**WARNING:** this is currently blocked because:

- we need https://github.com/wapc/wapc-rs/pull/153 to be merged, plus a new release of `wasmtime-provider` must be created
- we need to wait for Kubewarden 1.26 to be released
