### PR TITLE
feat(capability): add kubernetes/can-i capability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,10 @@ kube = { version = "1.0.0", default-features = false, features = [
   "runtime",
   "rustls-tls",
 ] }
-kubewarden-policy-sdk = { version = "0.13.4", features = ["crd"] }
+kubewarden-policy-sdk = { git = "https://github.com/jvanz/policy-sdk-rust", branch = "can-i", features = [
+  "crd",
+] }
+# kubewarden-policy-sdk = { version = "0.13.4", features = ["crd"] }
 lazy_static = "1.5"
 mail-parser = { version = "0.11", features = ["serde"] }
 picky = { version = "7.0.0-rc.8", default-features = false, features = [

--- a/src/callback_handler.rs
+++ b/src/callback_handler.rs
@@ -324,6 +324,13 @@ impl CallbackHandler {
                         }
                     )
                 }
+                CallbackRequestType::KubernetesCanI {
+                    subject_access_review,
+                } => {
+                    handle_callback!(req, format!("can_i"), "Service account has permissions", {
+                        kubernetes::can_i(kubernetes_client.as_mut(), &subject_access_review)
+                    })
+                }
             }
         });
     }

--- a/src/callback_handler/kubernetes.rs
+++ b/src/callback_handler/kubernetes.rs
@@ -3,10 +3,13 @@ mod reflector;
 
 use anyhow::{anyhow, Result};
 use cached::proc_macro::cached;
+use k8s_openapi::api::authorization::v1::SubjectAccessReviewStatus;
 use kube::core::ObjectList;
 use serde::Serialize;
 
 pub(crate) use client::Client;
+
+use crate::callback_requests::SubjectAccessReviewWrapper;
 
 #[derive(Eq, Hash, PartialEq)]
 struct ApiVersionKind {
@@ -142,4 +145,22 @@ pub(crate) async fn has_list_resources_all_result_changed_since_instant(
         )
         .await
         .map(cached::Return::new)
+}
+
+pub(crate) async fn can_i(
+    client: Option<&mut Client>,
+    subject_access_review: &SubjectAccessReviewWrapper,
+) -> Result<cached::Return<SubjectAccessReviewStatus>> {
+    if client.is_none() {
+        return Err(anyhow!("kube::Client was not initialized properly"));
+    }
+
+    client
+        .unwrap()
+        .can_i(subject_access_review.as_ref())
+        .await
+        .map(|value| cached::Return {
+            was_cached: false,
+            value,
+        })
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -267,6 +267,14 @@ async fn test_policy_evaluator(
     "app_deployment.json",
     rego_scenario
 )]
+// FIXME update the policy URI once the PR is merged and released:
+// https://github.com/kubewarden/context-aware-test-policy/pull/56
+#[case::wapc_cani(
+    PolicyExecutionMode::KubewardenWapc,
+    "ghcr.io/jvanz/policies/context-aware-test-policy:cani",
+    "app_deployment.json",
+    wapc_and_wasi_scenario
+)]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_runtime_context_aware<F, Fut>(
     #[case] execution_mode: PolicyExecutionMode,

--- a/tests/k8s_mock/fixtures.rs
+++ b/tests/k8s_mock/fixtures.rs
@@ -1,6 +1,7 @@
 use k8s_openapi::{
     api::{
         apps::v1::Deployment,
+        authorization::v1::SubjectAccessReviewStatus,
         core::v1::{Namespace, Service},
     },
     apimachinery::pkg::apis::meta::v1::{APIResource, APIResourceList},
@@ -156,6 +157,13 @@ pub(crate) fn api_auth_service() -> Service {
             resource_version: Some("1".to_owned()),
             ..Default::default()
         },
+        ..Default::default()
+    }
+}
+
+pub(crate) fn subjectaccessreviewsstatus() -> SubjectAccessReviewStatus {
+    SubjectAccessReviewStatus {
+        allowed: false,
         ..Default::default()
     }
 }

--- a/tests/k8s_mock/mod.rs
+++ b/tests/k8s_mock/mod.rs
@@ -71,6 +71,12 @@ pub(crate) async fn wapc_and_wasi_scenario(handle: Handle<Request<Body>, Respons
                 ) => {
                     send_response(send, fixtures::api_auth_service());
                 }
+                (
+                    &http::Method::POST,
+                    "/apis/authorization.k8s.io/v1/subjectaccessreviews",
+                    None,
+                    false,
+                ) => send_response(send, fixtures::subjectaccessreviewsstatus()),
                 _ => {
                     panic!("unexpected request: {:?}", request);
                 }


### PR DESCRIPTION
## Description

Adds new capability to allow policies to use the Kubernetes authorization API to check if a service account has permissions to perform some operations in resources.

Fix #715 

## Test

```shell
make test
```
