### PR TITLE
fix: allow js policies built by latest javy compiler to work

### DIFF
--- a/src/runtimes/wasi_cli/stack_pre.rs
+++ b/src/runtimes/wasi_cli/stack_pre.rs
@@ -61,60 +61,66 @@ impl StackPre {
 }
 
 fn add_host_call_to_linker(linker: &mut wasmtime::Linker<Context>) -> Result<()> {
+    let host_call_impl = |mut caller: wasmtime::Caller<'_, Context>,
+                          bd_ptr: i32,
+                          bd_len: i32,
+                          ns_ptr: i32,
+                          ns_len: i32,
+                          op_ptr: i32,
+                          op_len: i32,
+                          ptr: i32,
+                          len: i32| {
+        let memory_export = caller
+            .get_export("memory")
+            .ok_or_else(|| WasiRuntimeError::WasiMemExport)?;
+        let memory = memory_export
+            .into_memory()
+            .ok_or_else(|| WasiRuntimeError::WasiMemExportCannotConvert)?;
+
+        let stdin = caller.data().stdin_pipe.as_ref();
+
+        let vec = get_vec_from_memory(caller.as_context(), memory, ptr, len);
+        let bd_vec = get_vec_from_memory(caller.as_context(), memory, bd_ptr, bd_len);
+        let bd = std::str::from_utf8(&bd_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
+        let ns_vec = get_vec_from_memory(caller.as_context(), memory, ns_ptr, ns_len);
+        let ns = std::str::from_utf8(&ns_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
+        let op_vec = get_vec_from_memory(caller.as_context(), memory, op_ptr, op_len);
+        let op = std::str::from_utf8(&op_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
+
+        let host_callback_response = host_callback(bd, ns, op, &vec, &caller.data().eval_ctx);
+
+        // return 1 if the host callback failed, 0 otherwise
+        let func_return_value = host_callback_response.is_err() as i32;
+
+        let response_msg = match host_callback_response {
+            Ok(r) => r,
+            Err(e) => e.to_string().as_bytes().to_owned(),
+        };
+
+        let mut stdin_pipe = stdin
+            .write()
+            .map_err(|_| WasiRuntimeError::WasiWriteAccessStdin())?;
+        let _ = stdin_pipe
+            .write(&response_msg)
+            .map_err(|_| WasiRuntimeError::WasiCannotWriteStdin())?;
+        Ok(func_return_value)
+    };
+
     linker
-        .func_wrap(
-            "host",
-            "call",
-            |mut caller: wasmtime::Caller<'_, Context>,
-             bd_ptr: i32,
-             bd_len: i32,
-             ns_ptr: i32,
-             ns_len: i32,
-             op_ptr: i32,
-             op_len: i32,
-             ptr: i32,
-             len: i32| {
-                let memory_export = caller
-                    .get_export("memory")
-                    .ok_or_else(|| WasiRuntimeError::WasiMemExport)?;
-                let memory = memory_export
-                    .into_memory()
-                    .ok_or_else(|| WasiRuntimeError::WasiMemExportCannotConvert)?;
-
-                let stdin = caller.data().stdin_pipe.as_ref();
-
-                let vec = get_vec_from_memory(caller.as_context(), memory, ptr, len);
-                let bd_vec = get_vec_from_memory(caller.as_context(), memory, bd_ptr, bd_len);
-                let bd = std::str::from_utf8(&bd_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
-                let ns_vec = get_vec_from_memory(caller.as_context(), memory, ns_ptr, ns_len);
-                let ns = std::str::from_utf8(&ns_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
-                let op_vec = get_vec_from_memory(caller.as_context(), memory, op_ptr, op_len);
-                let op = std::str::from_utf8(&op_vec).map_err(WasiRuntimeError::WasiMemOpToUtF8)?;
-
-                let host_callback_response =
-                    host_callback(bd, ns, op, &vec, &caller.data().eval_ctx);
-
-                // return 1 if the host callback failed, 0 otherwise
-                let func_return_value = host_callback_response.is_err() as i32;
-
-                let response_msg = match host_callback_response {
-                    Ok(r) => r,
-                    Err(e) => e.to_string().as_bytes().to_owned(),
-                };
-
-                let mut stdin_pipe = stdin
-                    .write()
-                    .map_err(|_| WasiRuntimeError::WasiWriteAccessStdin())?;
-                let _ = stdin_pipe
-                    .write(&response_msg)
-                    .map_err(|_| WasiRuntimeError::WasiCannotWriteStdin())?;
-                Ok(func_return_value)
-            },
-        )
+        .func_wrap("host", "call", host_call_impl)
         .map_err(|e| WasiRuntimeError::WasmHostFuncDefinitionError {
             name: "host.call".to_string(),
             error: e.to_string(),
         })?;
+
+    // used by the JS policies
+    linker
+        .func_wrap("kubewarden:javy/host", "call", host_call_impl)
+        .map_err(|e| WasiRuntimeError::WasmHostFuncDefinitionError {
+            name: "kubewarden:javy/host:call".to_string(),
+            error: e.to_string(),
+        })?;
+
     Ok(())
 }
 


### PR DESCRIPTION
> This is a DRAFT PR: we have to decide how we want to solve this problem, an alternative solution is the one of PR https://github.com/kubewarden/kwctl/pull/1388

Our JavaScript/TypeScript policies are written using the Javy compiler and they necessitate a custom Javy pluging to work.

The Javy plugin defines some functions used by the js VM, plus it imports the usual `host:call` function from the WebAssembly host.

Everything was working fine until the javy-plugin version `4.0.0` was released.

This release requires to build our plugin using the wasip2 target, which in turns forces the usage of the WebAssembly component model. However, at this time, the javy compiler (v7.0.0) produces wasip1 modules instead of wasm components.

Among other changes, unrelated to this commit, the intermediate usage of the component model reduces the control we have over the final name of the function that is imported from the wasm host.

As a result, the latest js policies will import the `kubewarden:javy/host:call` function instead of the traditional `host:call` one.

This commit changes our WASI runtime to define an additional host function named in the same way that javy expects.
